### PR TITLE
Fix getFixedT function always returning values in current language

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,32 @@ To do that, you can pass an array of required namespaces for each page into `ser
 
 Note: `useTranslation` provides namespaces to the component that you use it in. However, `serverSideTranslations` provides the total available namespaces to the entire React tree and belongs on the page level. Both are required.
 
-### 5. Advanced configuration
+### 5. Declaring locale dependencies
+
+By default, `next-i18next` will send _only the active locale_ down to the client on each request. This helps reduce the size of the
+initial payload send to the client. However in some cases one may need the translations for other languages at runtime too. For example
+when using [getFixedT](https://www.i18next.com/overview/api#getfixedt) of `useTranslation` hook.
+
+To change the behavior and load extra locales just pass in an array of locales as the last argument to `serverSideTranslations`.
+
+```diff
+  import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+
+  export async function getStaticProps({ locale }) {
+    return {
+      props: {
+-       ...(await serverSideTranslations(locale, ['common', 'footer'])),
++       ...(await serverSideTranslations(locale, ['common', 'footer'], null, ['en', 'no'])),
+      },
+    };
+  }
+```
+
+As a result the translations for both `no` and `en` locales will always be loaded regardless of the current language.
+
+> Note: The extra argument should be added to all pages that use `getFixedT` function.
+
+### 6. Advanced configuration
 
 #### Passing other config options
 

--- a/src/serverSideTranslations.test.tsx
+++ b/src/serverSideTranslations.test.tsx
@@ -184,6 +184,59 @@ describe('serverSideTranslations', () => {
         'namespace-of-en',
       ])
     })
+
+    it('loads extra locales when extraLocales is provided', async () => {
+      const props = await serverSideTranslations('en-US', undefined, {
+        i18n: {
+          defaultLocale: 'en-US',
+          locales: ['en-US', 'fr-BE', 'nl-BE'],
+        },
+      } as UserConfig, ['en-US', 'fr-BE', 'fr-BE'])
+
+      expect(fs.readdirSync).toHaveBeenCalledTimes(2)
+      expect(fs.readdirSync).toHaveBeenCalledWith(expect.stringMatching('/public/locales/en'))
+      expect(fs.readdirSync).toHaveBeenCalledWith(expect.stringMatching('/public/locales/fr'))
+      expect(props._nextI18Next.initialI18nStore)
+        .toEqual({
+          'en-US': {
+            common: {},
+            'namespace-of-en-US': {},
+            'namespace-of-fr-BE': {},
+          },
+          'fr-BE': {
+            common: {},
+            'namespace-of-en-US': {},
+            'namespace-of-fr-BE': {},
+          },
+        })
+      expect(props._nextI18Next.ns).toEqual([
+        'common',
+        'namespace-of-en-US',
+        'namespace-of-fr-BE',
+      ])
+    })
+
+    it('does not load extra locales when extraLocales is false', async () => {
+      const props = await serverSideTranslations('en-US', undefined, {
+        i18n: {
+          defaultLocale: 'en-US',
+          locales: ['en-US', 'fr-BE', 'nl-BE'],
+        },
+      } as UserConfig, false)
+
+      expect(props._nextI18Next.initialI18nStore)
+        .toEqual({
+          'en-US': {
+            common: {},
+            'namespace-of-en-US': {},
+          },
+        })
+
+      expect(props._nextI18Next.ns).toEqual([
+        'common',
+        'namespace-of-en-US',
+      ])
+    })
   })
 
   it('returns props', async () => {

--- a/src/serverSideTranslations.ts
+++ b/src/serverSideTranslations.ts
@@ -11,17 +11,17 @@ import { FallbackLng } from 'i18next'
 
 const DEFAULT_CONFIG_PATH = './next-i18next.config.js'
 
-const getFallbackLocales = (fallbackLng: false | FallbackLng) => {
-  if (typeof fallbackLng === 'string') {
-    return [fallbackLng]
+const flatLocales = (locales: false | FallbackLng) => {
+  if (typeof locales === 'string') {
+    return [locales]
   }
-  if (Array.isArray(fallbackLng)) {
-    return fallbackLng
+  if (Array.isArray(locales)) {
+    return locales
   }
-  if (typeof fallbackLng === 'object' && fallbackLng !== null) {
+  if (typeof locales === 'object' && locales !== null) {
     return Object
-      .values(fallbackLng)
-      .reduce((all, locales) => [...all, ...locales],[])
+      .values(locales)
+      .reduce((all, items) => [...all, ...items],[])
   }
   return []
 }
@@ -38,7 +38,7 @@ export const serverSideTranslations = async (
   initialLocale: string,
   namespacesRequired: string[] | undefined = undefined,
   configOverride: UserConfig | null = null,
-  extraLocales: string[] | undefined = undefined,
+  extraLocales: string[] | false = false,
 ): Promise<SSRConfig> => {
   if (typeof initialLocale !== 'string') {
     throw new Error('Initial locale argument was not passed into serverSideTranslations')
@@ -81,9 +81,11 @@ export const serverSideTranslations = async (
     [initialLocale]: {},
   }
 
-  getFallbackLocales(fallbackLng).concat(extraLocales || []).forEach((lng: string) => {
-    initialI18nStore[lng] = {}
-  })
+  flatLocales(fallbackLng)
+    .concat(flatLocales(extraLocales))
+    .forEach((lng: string) => {
+      initialI18nStore[lng] = {}
+    })
 
   if (!Array.isArray(namespacesRequired)) {
     if (typeof localePath === 'function') {

--- a/src/serverSideTranslations.ts
+++ b/src/serverSideTranslations.ts
@@ -38,6 +38,7 @@ export const serverSideTranslations = async (
   initialLocale: string,
   namespacesRequired: string[] | undefined = undefined,
   configOverride: UserConfig | null = null,
+  extraLocales: string[] | undefined = undefined,
 ): Promise<SSRConfig> => {
   if (typeof initialLocale !== 'string') {
     throw new Error('Initial locale argument was not passed into serverSideTranslations')
@@ -80,7 +81,7 @@ export const serverSideTranslations = async (
     [initialLocale]: {},
   }
 
-  getFallbackLocales(fallbackLng).forEach((lng: string) => {
+  getFallbackLocales(fallbackLng).concat(extraLocales || []).forEach((lng: string) => {
     initialI18nStore[lng] = {}
   })
 


### PR DESCRIPTION
I was running into an issue where `getFixedT` always returned values in the current language not the requested language. I found  this issue - https://github.com/i18next/next-i18next/issues/1184 about it. The fix for it was merged in and released and seemed to work. However a bit later the fix got reverted as people did not expect all locales to be loaded by the library. See the following issue - https://github.com/i18next/next-i18next/issues/1267.

This PR proposes a potential new argument to the `serverSideTranslations` function (could also be a config override field really). This argument can be used to provide extra locales to load for the specific page and allows one to opt into loading more or all locales. As a result `getFixedT` will then work for the locales that are loaded for the page.

> If the general direction/idea is accepted I will clean this PR up and will add tests/documentation updates too.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

