### PR TITLE
Improve fallback language handling

### DIFF
--- a/src/appWithTranslation.server.test.tsx
+++ b/src/appWithTranslation.server.test.tsx
@@ -79,7 +79,7 @@ describe('appWithTranslation', () => {
     expect(args[0].i18n.language).toBe('en')
     expect(args[0].i18n.isInitialized).toBe(true)
 
-    expect(fs.existsSync).toHaveBeenCalledTimes(1)
+    expect(fs.existsSync).toHaveBeenCalledTimes(3)
     expect(fs.readdirSync).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/config/createConfig.test.ts
+++ b/src/config/createConfig.test.ts
@@ -156,6 +156,26 @@ describe('createConfig', () => {
 
       })
 
+      it('does not throw an error if fallback (as function) exists', () => {
+        (fs.existsSync as jest.Mock).mockReset();
+        (fs.existsSync as jest.Mock).mockReturnValueOnce(false)
+          .mockReturnValueOnce(true)
+
+        const config = createConfig({
+          fallbackLng: (code) => code.split('-')[0],
+          i18n: {
+            defaultLocale: 'de',
+            locales: ['de', 'en', 'en-US'],
+          },
+          lng: 'en-US',
+        } as UserConfig)
+
+        expect(typeof config.fallbackLng).toBe('function')
+        expect(fs.existsSync).toHaveBeenCalledWith('public/locales/en-US/common.json')
+        expect(fs.existsSync).toHaveBeenCalledWith('public/locales/en/common.json')
+        expect(fs.existsSync).toHaveBeenCalledTimes(4)
+      })
+
       it('uses user provided prefix/suffix with localeStructure', () => {
         (fs.existsSync as jest.Mock).mockReset();
         (fs.existsSync as jest.Mock).mockReturnValueOnce(false)

--- a/src/config/createConfig.test.ts
+++ b/src/config/createConfig.test.ts
@@ -51,7 +51,7 @@ describe('createConfig', () => {
         expect(config.interpolation?.escapeValue).toBe(false)
         expect(config.interpolation?.format).toBeUndefined()
 
-        expect(fs.existsSync).toHaveBeenCalledTimes(1)
+        expect(fs.existsSync).toHaveBeenCalledTimes(3)
         expect(fs.readdirSync).toHaveBeenCalledTimes(1)
       })
 
@@ -123,6 +123,7 @@ describe('createConfig', () => {
 
     describe('defaultNS validation', () => {
       it('when filesystem is missing defaultNS throws an error', () => {
+        (fs.existsSync as jest.Mock).mockReset();
         (fs.existsSync as jest.Mock).mockReturnValueOnce(false)
 
         const config = createConfig.bind(null, {
@@ -295,7 +296,7 @@ describe('createConfig', () => {
         expect(config.interpolation?.escapeValue).toBe(false)
         expect(config.interpolation?.format).toBeUndefined()
 
-        expect(fs.existsSync).toHaveBeenCalledTimes(1)
+        expect(fs.existsSync).toHaveBeenCalledTimes(4)
         expect(fs.readdirSync).toHaveBeenCalledTimes(2)
         expect(fs.statSync).toHaveBeenCalledTimes(2)
       })

--- a/src/config/createConfig.test.ts
+++ b/src/config/createConfig.test.ts
@@ -132,7 +132,31 @@ describe('createConfig', () => {
         expect(config).toThrow('Default namespace not found at public/locales/en/common.json')
       })
 
+      it('does not throw an error if fallback exists', () => {
+        (fs.existsSync as jest.Mock).mockReset();
+        (fs.existsSync as jest.Mock).mockReturnValueOnce(false)
+          .mockReturnValueOnce(true)
+
+        const config = createConfig({
+          fallbackLng: {
+            'en-US': ['en'],
+          },
+          i18n: {
+            defaultLocale: 'de',
+            locales: ['de', 'en', 'en-US'],
+          },
+          lng: 'en-US',
+        } as UserConfig)
+
+        expect(config.fallbackLng).toStrictEqual({ 'en-US': ['en'] })
+        expect(fs.existsSync).toHaveBeenCalledWith('public/locales/en-US/common.json')
+        expect(fs.existsSync).toHaveBeenCalledWith('public/locales/en/common.json')
+        expect(fs.existsSync).toHaveBeenCalledTimes(4)
+
+      })
+
       it('uses user provided prefix/suffix with localeStructure', () => {
+        (fs.existsSync as jest.Mock).mockReset();
         (fs.existsSync as jest.Mock).mockReturnValueOnce(false)
 
         const config = createConfig.bind(null, {

--- a/src/config/createConfig.ts
+++ b/src/config/createConfig.ts
@@ -1,6 +1,6 @@
 import { defaultConfig } from './defaultConfig'
 import { InternalConfig, UserConfig } from '../types'
-import { FallbackLng } from 'i18next'
+import { FallbackLng, FallbackLngObjList } from 'i18next'
 
 const deepMergeObjects = ['backend', 'detection'] as (keyof Pick<UserConfig, 'backend' | 'detection'>)[]
 
@@ -56,6 +56,29 @@ export const createConfig = (userConfig: UserConfig): InternalConfig => {
       // https://github.com/i18next/next-i18next/issues/358
       //
       if (typeof defaultNS === 'string' && typeof lng !== 'undefined') {
+        const getFallbackForLng = (
+          lng: string,
+          fallbackLng: false | FallbackLng
+        ): string[] => {
+          if (typeof fallbackLng === 'string') {
+            return [fallbackLng]
+          }
+
+          if (Array.isArray(fallbackLng)) {
+            return fallbackLng
+          }
+
+          if (typeof fallbackLng === 'object') {
+            return [...(fallbackLng as FallbackLngObjList)[lng] ?? []]
+          }
+
+          if (typeof fallbackLng === 'function') {
+            return getFallbackForLng(lng, fallbackLng(lng))
+          }
+
+          return []
+        }
+
         if (typeof localePath === 'string') {
           const prefix = userConfig?.interpolation?.prefix ?? '{{'
           const suffix = userConfig?.interpolation?.suffix ?? '}}'
@@ -63,13 +86,24 @@ export const createConfig = (userConfig: UserConfig): InternalConfig => {
           const defaultFile = `/${defaultLocaleStructure}.${localeExtension}`
           const defaultNSPath = path.join(localePath, defaultFile)
           const defaultNSExists = fs.existsSync(defaultNSPath)
-          if (!defaultNSExists && process.env.NODE_ENV !== 'production') {
+          const fallback = getFallbackForLng(lng, combinedConfig.fallbackLng)
+          const defaultFallbackNSExists = fallback.some(f => {
+            const fallbackFile = defaultFile.replace(lng, f)
+            const defaultNSPath = path.join(localePath, fallbackFile)
+            return fs.existsSync(defaultNSPath)
+          })
+          if (!defaultNSExists && !defaultFallbackNSExists && process.env.NODE_ENV !== 'production') {
             throw new Error(`Default namespace not found at ${defaultNSPath}`)
           }
         } else if (typeof localePath === 'function') {
           const defaultNSPath = localePath(lng, defaultNS, false)
           const defaultNSExists = fs.existsSync(defaultNSPath)
-          if (!defaultNSExists && process.env.NODE_ENV !== 'production') {
+          const fallback = getFallbackForLng(lng, combinedConfig.fallbackLng)
+          const defaultFallbackNSExists = fallback.some(f => {
+            const defaultNSPath = localePath(f, defaultNS, false)
+            return fs.existsSync(defaultNSPath)
+          })
+          if (!defaultNSExists && !defaultFallbackNSExists && process.env.NODE_ENV !== 'production') {
             throw new Error(`Default namespace not found at ${defaultNSPath}`)
           }
         }
@@ -106,6 +140,9 @@ export const createConfig = (userConfig: UserConfig): InternalConfig => {
         const getNamespaces = (locales: string[]): string[] => {
           const getLocaleNamespaces = (p: string) => {
             let ret: string[] = []
+
+            if (!fs.existsSync(p)) return ret
+
             fs.readdirSync(p).map(
               (file: string) => {
                 const joinedP = path.join(p, file)

--- a/src/config/createConfig.ts
+++ b/src/config/createConfig.ts
@@ -186,6 +186,11 @@ export const createConfig = (userConfig: UserConfig): InternalConfig => {
               .reduce(((all, fallbackLngs) => [ ...all, ...fallbackLngs ]),[])
             return unique([ lng, ...flattenedFallbacks ])
           }
+
+          if (typeof fallbackLng === 'function') {
+            return getAllLocales(lng, fallbackLng(lng))
+          }
+
           return [lng]
         }
 

--- a/src/serverSideTranslations.ts
+++ b/src/serverSideTranslations.ts
@@ -81,7 +81,11 @@ export const serverSideTranslations = async (
     [initialLocale]: {},
   }
 
-  flatLocales(fallbackLng)
+  flatLocales(
+    typeof fallbackLng === 'function'
+      ? fallbackLng(initialLocale)
+      : fallbackLng ?? false
+  )
     .concat(flatLocales(extraLocales))
     .forEach((lng: string) => {
       initialI18nStore[lng] = {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,6 @@ export type UserConfig = {
 
 export type InternalConfig = Omit<UserConfig, 'i18n'> & NextJsI18NConfig & {
   errorStackTraceLimit: number
-  fallbackLng: boolean
   // end temporal backwards compatibility WHITELIST REMOVAL
   preload: string[]
   supportedLngs: string[]


### PR DESCRIPTION
We currently have the use case to provide multiple locales (`de`, `de-AT`, `de-DE`, `de-CH`) for one language (`de`) without the need for individual translations. Preferably we would like to use a function for `fallbackLng`, like `(code) => code.split('-')[0]`, as we need to support a wide range of locales.

When using `fallbackLng` like this, we still need to provide JSON files for each locale, although the translations for `de-AT` are no different than for `de`. This PR is an attempt to fix this and I think it is related to https://github.com/i18next/next-i18next/issues/1652, https://github.com/i18next/next-i18next/discussions/1649 and https://github.com/i18next/next-i18next/issues/1465.

Depending on the setup, the changes of this PR might add multiple fallback locales to `window.__NEXT_DATA__`. This could lead to increased page size. Should we add a notice about this in the docs?

Additionally we could utilize the config `nonExplicitSupportedLngs` to automatically add fallbacks per locale (e.g. `de` for `de-AT`). If understood correctly, this would reduce setup complexity and remove the need of `serializeConfig: false` - because a function for `fallbackLng` would no longer be necessary. Do you think this would be the expected behavior @adrai? Otherwise we could add a short notice to the docs, that this option is currently not supported with next-i18next as this was my first (incorrect) assumption. This might be related to https://github.com/i18next/next-i18next/issues/1412.

I‘m quite new to the code base and very happy about feedback, alternative solutions or improvement suggestions for this PR. Thank you!

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)