### PR TITLE
Add support for nonExplicitSupportedLngs

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,30 @@ As a result the translations for both `no` and `en` locales will always be loade
 
 > Note: The extra argument should be added to all pages that use `getFixedT` function.
 
+#### Fallback locales
+By default, `next-i18next` will add the `defaultLocale` as fallback. To change this, you can set [`fallbackLng`](https://www.i18next.com/principles/fallback). All values supported by `i18next` (`string`, `array`, `object` and `function`) are supported by `next-i18next` too.
+
+Additionally `nonExplicitSupportedLngs` can be set to `true` to support all variants of a language, without the need to provide JSON files for each of them. Notice that all variants still must be included in `locales` to enable routing within `next.js`.
+
+> Note: `fallbackLng` and `nonExplicitSupportedLngs` can be used at once. There is only one exception: You can not use a function for `fallbackLng` when `nonExplicitSupportedLngs` is `true`,
+
+```js
+module.exports = {
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en', 'fr', 'de-AT', 'de-DE', 'de-CH'],
+  },
+  fallbackLng: [
+    default: ['en'],
+    'de-CH': ['fr']
+  ],
+  nonExplicitSupportedLngs: true,
+  // de, fr and en will be loaded as fallback languages for de-CH
+};
+```
+
+Be aware that using `fallbackLng` and `nonExplicitSupportedLngs` can easily increase the initial size of the page.
+
 ### 6. Advanced configuration
 
 #### Passing other config options

--- a/src/config/createConfig.test.ts
+++ b/src/config/createConfig.test.ts
@@ -197,6 +197,26 @@ describe('createConfig', () => {
         expect(fs.existsSync).toHaveBeenCalledTimes(4)
       })
 
+      it('does not throw an error if nonExplicitSupportedLngs is true', () => {
+        (fs.existsSync as jest.Mock).mockReset();
+        (fs.existsSync as jest.Mock).mockReturnValueOnce(false)
+          .mockReturnValueOnce(true)
+
+        const config = createConfig({
+          i18n: {
+            defaultLocale: 'de',
+            locales: ['de', 'en-US'],
+          },
+          lng: 'en-US',
+          nonExplicitSupportedLngs: true,
+        } as UserConfig)
+
+        expect(typeof config.nonExplicitSupportedLngs).toBe('boolean')
+        expect(fs.existsSync).toHaveBeenCalledWith('public/locales/en-US/common.json')
+        expect(fs.existsSync).toHaveBeenCalledWith('public/locales/en/common.json')
+        expect(fs.existsSync).toHaveBeenCalledTimes(5)
+      })
+
       it('uses user provided prefix/suffix with localeStructure', () => {
         (fs.existsSync as jest.Mock).mockReset();
         (fs.existsSync as jest.Mock).mockReturnValueOnce(false)

--- a/src/config/createConfig.test.ts
+++ b/src/config/createConfig.test.ts
@@ -68,7 +68,7 @@ describe('createConfig', () => {
       it('gets namespaces from current language + fallback (as object) when ns is not provided', ()=>{
         const fallbackLng = { default: ['fr'], 'en-US': ['en'] } as unknown
         const config = createConfig({ fallbackLng, lng: 'en-US' } as UserConfig)
-        expect(config.ns).toEqual(['namespace-of-en-US', 'namespace-of-fr', 'namespace-of-en'])
+        expect(config.ns).toEqual(['namespace-of-en-US', 'namespace-of-en', 'namespace-of-fr'])
       })
 
       it('deep merges backend', () => {
@@ -153,8 +153,29 @@ describe('createConfig', () => {
         expect(fs.existsSync).toHaveBeenCalledWith('public/locales/en-US/common.json')
         expect(fs.existsSync).toHaveBeenCalledWith('public/locales/en/common.json')
         expect(fs.existsSync).toHaveBeenCalledTimes(4)
-
       })
+
+      it('does not throw error if fallbackLng has default key and it exists', () => {
+        (fs.existsSync as jest.Mock).mockReset();
+        (fs.existsSync as jest.Mock).mockReturnValueOnce(false)
+          .mockReturnValueOnce(true)
+
+        createConfig({
+          fallbackLng: {
+            default: ['en'],
+          },
+          i18n: {
+            defaultLocale: 'de',
+            locales: ['de', 'en', 'en-US'],
+          },
+          lng: 'en-US',
+        } as UserConfig)
+
+        expect(fs.existsSync).toHaveBeenCalledWith('public/locales/en-US/common.json')
+        expect(fs.existsSync).toHaveBeenCalledWith('public/locales/en/common.json')
+        expect(fs.existsSync).toHaveBeenCalledTimes(4)
+      })
+
 
       it('does not throw an error if fallback (as function) exists', () => {
         (fs.existsSync as jest.Mock).mockReset();

--- a/src/serverSideTranslations.test.tsx
+++ b/src/serverSideTranslations.test.tsx
@@ -323,6 +323,101 @@ describe('serverSideTranslations', () => {
     ])
   })
 
+  describe('When nonExplicitSupportedLngs is true', () => {
+
+    it('does load fallback locales', async () => {
+      const props = await serverSideTranslations('en-US', ['common'], {
+        i18n: {
+          defaultLocale: 'de',
+          locales: ['de', 'en-US'],
+        },
+        nonExplicitSupportedLngs: true,
+      } as UserConfig, false)
+
+      expect(props._nextI18Next.initialI18nStore)
+        .toEqual({
+          de: {
+            common: {},
+          },
+          en: {
+            common: {},
+          },
+          'en-US': {
+            common: {},
+          },
+        })
+    })
+
+    it('does load fallback locales with fallbackLng (as array)', async () => {
+      const props = await serverSideTranslations('en-US', ['common'], {
+        fallbackLng: ['fr'],
+        i18n: {
+          defaultLocale: 'de',
+          locales: ['de', 'en-US', 'fr'],
+        },
+        nonExplicitSupportedLngs: true,
+      } as UserConfig, false)
+
+      expect(props._nextI18Next.initialI18nStore)
+        .toEqual({
+          en: {
+            common: {},
+          },
+          'en-US': {
+            common: {},
+          },
+          fr: {
+            common: {},
+          },
+        })
+    })
+
+    it('does load fallback locales with fallbackLng (as object)', async () => {
+      const props = await serverSideTranslations('en-US', ['common'], {
+        fallbackLng: {
+          default: ['fr'],
+          'en-US': ['de'],
+        },
+        i18n: {
+          defaultLocale: 'de',
+          locales: ['de', 'en-US', 'de-DE'],
+        },
+        nonExplicitSupportedLngs: true,
+      } as UserConfig, false)
+
+      expect(props._nextI18Next.initialI18nStore)
+        .toEqual({
+          de: {
+            common: {},
+          },
+          en: {
+            common: {},
+          },
+          'en-US': {
+            common: {},
+          },
+          fr: {
+            common: {},
+          },
+
+        })
+    })
+
+    it('does thrown an error with fallbackLng (as function)', async () => {
+      const config: UserConfig = {
+        fallbackLng: (code) => code === 'de-AT' ? 'de' : 'en',
+        i18n: {
+          defaultLocale: 'de',
+          locales: ['de', 'en-US', 'de-DE'],
+        },
+        nonExplicitSupportedLngs: true,
+      }
+
+      await expect(serverSideTranslations('de-DE', ['common'], config))
+        .rejects.toThrow('If nonExplicitSupportedLngs is true, no functions are allowed for fallbackLng')
+    })
+  })
+
   it('returns props', async () => {
     const props = await serverSideTranslations('en-US', [], {
       i18n: {

--- a/src/serverSideTranslations.test.tsx
+++ b/src/serverSideTranslations.test.tsx
@@ -150,29 +150,21 @@ describe('serverSideTranslations', () => {
         i18n: {
           defaultLocale: 'nl-BE',
           fallbackLng: { default: ['fr'], 'nl-BE': ['en'] },
-          locales: ['nl-BE', 'fr-BE'],
+          locales: ['nl-BE', 'fr-BE', 'en-US'],
         },
       } as UserConfig)
-      expect(fs.readdirSync).toHaveBeenCalledTimes(3)
-      expect(fs.readdirSync).toHaveBeenCalledWith(expect.stringMatching('/public/locales/en'))
+      expect(fs.readdirSync).toHaveBeenCalledTimes(2)
+      expect(fs.readdirSync).toHaveBeenCalledWith(expect.stringMatching('/public/locales/en-US'))
       expect(fs.readdirSync).toHaveBeenCalledWith(expect.stringMatching('/public/locales/fr'))
       expect(props._nextI18Next.initialI18nStore)
         .toEqual({
-          en: {
-            common: {},
-            'namespace-of-en': {},
-            'namespace-of-en-US': {},
-            'namespace-of-fr': {},
-          },
           'en-US': {
             common: {},
-            'namespace-of-en': {},
             'namespace-of-en-US': {},
             'namespace-of-fr': {},
           },
           fr: {
             common: {},
-            'namespace-of-en': {},
             'namespace-of-en-US': {},
             'namespace-of-fr': {},
           },
@@ -181,7 +173,6 @@ describe('serverSideTranslations', () => {
         'common',
         'namespace-of-en-US',
         'namespace-of-fr',
-        'namespace-of-en',
       ])
     })
 
@@ -258,6 +249,78 @@ describe('serverSideTranslations', () => {
         'namespace-of-en-US',
       ])
     })
+  })
+
+  it('does load fallback locales with fallbackLng (as array)', async () => {
+    const props = await serverSideTranslations('en-US', ['common'], {
+      fallbackLng: ['de'],
+      i18n: {
+        defaultLocale: 'de',
+        locales: ['de', 'en-US', 'de-AT'],
+      },
+    } as UserConfig, false)
+
+    expect(props._nextI18Next.initialI18nStore)
+      .toEqual({
+        de: {
+          common: {},
+        },
+        'en-US': {
+          common: {},
+        },
+      })
+
+    expect(props._nextI18Next.ns).toEqual([
+      'common',
+    ])
+  })
+
+  it('does load fallback locales with fallbackLng (as object)', async () => {
+    const props = await serverSideTranslations('en-US', ['common'], {
+      fallbackLng: { 'de-AT': ['de'], default: ['en'] },
+      i18n: {
+        defaultLocale: 'de',
+        locales: ['de', 'en-US', 'de-AT'],
+      },
+    } as UserConfig, false)
+
+    expect(props._nextI18Next.initialI18nStore)
+      .toEqual({
+        en: {
+          common: {},
+        },
+        'en-US': {
+          common: {},
+        },
+      })
+
+    expect(props._nextI18Next.ns).toEqual([
+      'common',
+    ])
+  })
+
+  it('does load fallback locales with fallbackLng (as function)', async () => {
+    const props = await serverSideTranslations('en-US', ['common'], {
+      fallbackLng: (code) => code.split('-')[0],
+      i18n: {
+        defaultLocale: 'de',
+        locales: ['de', 'en-US'],
+      },
+    } as UserConfig, false)
+
+    expect(props._nextI18Next.initialI18nStore)
+      .toEqual({
+        en: {
+          common: {},
+        },
+        'en-US': {
+          common: {},
+        },
+      })
+
+    expect(props._nextI18Next.ns).toEqual([
+      'common',
+    ])
   })
 
   it('returns props', async () => {

--- a/src/serverSideTranslations.ts
+++ b/src/serverSideTranslations.ts
@@ -7,24 +7,9 @@ import createClient from './createClient'
 import { globalI18n } from './appWithTranslation'
 
 import { UserConfig, SSRConfig } from './types'
-import { FallbackLng } from 'i18next'
+import { getFallbackForLng } from './utils'
 
 const DEFAULT_CONFIG_PATH = './next-i18next.config.js'
-
-const flatLocales = (locales: false | FallbackLng) => {
-  if (typeof locales === 'string') {
-    return [locales]
-  }
-  if (Array.isArray(locales)) {
-    return locales
-  }
-  if (typeof locales === 'object' && locales !== null) {
-    return Object
-      .values(locales)
-      .reduce((all, items) => [...all, ...items],[])
-  }
-  return []
-}
 
 const flatNamespaces = (namespacesByLocale: string[][]) => {
   const allNamespaces = []
@@ -81,12 +66,8 @@ export const serverSideTranslations = async (
     [initialLocale]: {},
   }
 
-  flatLocales(
-    typeof fallbackLng === 'function'
-      ? fallbackLng(initialLocale)
-      : fallbackLng ?? false
-  )
-    .concat(flatLocales(extraLocales))
+  getFallbackForLng(initialLocale, fallbackLng ?? false)
+    .concat((extraLocales || []))
     .forEach((lng: string) => {
       initialI18nStore[lng] = {}
     })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,26 @@
+import { FallbackLng, FallbackLngObjList } from 'i18next'
+
+export const getFallbackForLng = (
+  lng: string,
+  fallbackLng: false | FallbackLng
+): string[] => {
+  if (typeof fallbackLng === 'string') {
+    return [fallbackLng]
+  }
+
+  if (Array.isArray(fallbackLng)) {
+    return fallbackLng
+  }
+
+  if (typeof fallbackLng === 'object') {
+    const fallbackList = (fallbackLng as FallbackLngObjList)[lng]
+    const fallbackDefault = (fallbackLng as FallbackLngObjList).default
+    return [...(fallbackList ?? []), ...fallbackDefault ?? []]
+  }
+
+  if (typeof fallbackLng === 'function') {
+    return getFallbackForLng(lng, fallbackLng(lng))
+  }
+
+  return []
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,3 +24,5 @@ export const getFallbackForLng = (
 
   return []
 }
+
+export const unique = (list: string[]) => Array.from(new Set<string>(list))


### PR DESCRIPTION
This PR adds support for `nonExplicitSupportedLngs` and is related to #1412. This features adds the possibility to support multiple variants of a language (`de-AT`, `de-CH` and `de-DE`) with a single JSON file (e.g. `public/locales/de/common.js`).

During the work on this PR I noticed that the the `default` value in `fallbackLng` should always be loaded. At least this is how I interprete this [testcase](https://github.com/i18next/next-i18next/pull/1930/files#diff-c87087f0d6c0b23943183ea270e1b1926cdf23e8bc7b7ae013762816561db596L152). Although this is related to #1927, the fix is part of this PR, because `nonExplicitSupportedLngs` depends on the same logic. Regarding the test-case above: I added `en-US` to supported `locales` and removed `en` from the `initialI18nStore`, because I think this should be the expected behavior. Is this correct @adrai?

Currently the combination `fallbackLng` with a function and `nonExplicitSupportedLngs: true` is not supported. Mainly because I didn't know how this could be implemented 😅 But I guess that the use cases for this combination should be very rare.

I'm looking forward to your feedback @adrai, thank you! 

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)