### PR TITLE
Fix fallbackLng if namespaces are undefined

### DIFF
--- a/src/serverSideTranslations.test.tsx
+++ b/src/serverSideTranslations.test.tsx
@@ -41,8 +41,7 @@ const renderDummyComponent = () =>
 
 describe('serverSideTranslations', () => {
   beforeEach(() => {
-    (fs.existsSync as jest.Mock).mockReturnValueOnce(false);
-    (fs.existsSync as jest.Mock).mockReturnValueOnce(true);
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
     (fs.readdirSync as jest.Mock).mockReturnValue([])
   })
   afterEach(jest.resetAllMocks)
@@ -65,7 +64,7 @@ describe('serverSideTranslations', () => {
           locales: ['en-US', 'fr-CA'],
         },
       } as UserConfig)
-      expect(fs.existsSync).toHaveBeenCalledTimes(0)
+      expect(fs.existsSync).toHaveBeenCalledTimes(1)
       expect(fs.readdirSync).toHaveBeenCalledTimes(1)
       expect(fs.readdirSync).toHaveBeenCalledWith(expect.stringMatching('/public/locales/en-US'))
       expect(props._nextI18Next.initialI18nStore)
@@ -83,7 +82,7 @@ describe('serverSideTranslations', () => {
         i18n: {
           defaultLocale: 'fr-BE',
           fallbackLng: 'fr',
-          locales: ['nl-BE', 'fr-BE'],
+          locales: ['nl-BE', 'fr-BE', 'en-US'],
         },
       } as UserConfig)
       expect(fs.readdirSync).toHaveBeenCalledTimes(2)

--- a/src/serverSideTranslations.test.tsx
+++ b/src/serverSideTranslations.test.tsx
@@ -9,6 +9,7 @@ import { appWithTranslation } from './appWithTranslation'
 jest.mock('fs', () => ({
   existsSync: jest.fn(),
   readdirSync: jest.fn(),
+  statSync: jest.fn(),
 }))
 
 const DummyApp = appWithTranslation(() => (
@@ -40,9 +41,15 @@ const renderDummyComponent = () =>
   )
 
 describe('serverSideTranslations', () => {
+  beforeAll(() => {
+    Object.assign(process, { browser: false })
+    delete (global as any).window
+  })
+
   beforeEach(() => {
     (fs.existsSync as jest.Mock).mockReturnValue(true);
-    (fs.readdirSync as jest.Mock).mockReturnValue([])
+    (fs.readdirSync as jest.Mock).mockReturnValue([]);
+    (fs.statSync as jest.Mock).mockImplementation(()=>({isDirectory:()=>false}))
   })
   afterEach(jest.resetAllMocks)
 
@@ -64,8 +71,10 @@ describe('serverSideTranslations', () => {
           locales: ['en-US', 'fr-CA'],
         },
       } as UserConfig)
-      expect(fs.existsSync).toHaveBeenCalledTimes(1)
-      expect(fs.readdirSync).toHaveBeenCalledTimes(1)
+
+      expect(fs.existsSync).toHaveBeenCalledTimes(4)
+      expect(fs.existsSync).toHaveBeenCalledWith(expect.stringMatching('/public/locales/en-US'))
+      expect(fs.readdirSync).toHaveBeenCalledTimes(2)
       expect(fs.readdirSync).toHaveBeenCalledWith(expect.stringMatching('/public/locales/en-US'))
       expect(props._nextI18Next.initialI18nStore)
         .toEqual({
@@ -85,7 +94,12 @@ describe('serverSideTranslations', () => {
           locales: ['nl-BE', 'fr-BE', 'en-US'],
         },
       } as UserConfig)
-      expect(fs.readdirSync).toHaveBeenCalledTimes(2)
+
+      expect(fs.existsSync).toHaveBeenCalledTimes(6)
+      expect(fs.existsSync).toHaveBeenCalledWith(expect.stringMatching('/public/locales/en-US'))
+      expect(fs.existsSync).toHaveBeenCalledWith(expect.stringMatching('/public/locales/fr'))
+      expect(fs.readdirSync).toHaveBeenCalledTimes(4)
+      expect(fs.readdirSync).toHaveBeenCalledWith(expect.stringMatching('/public/locales/en-US'))
       expect(fs.readdirSync).toHaveBeenCalledWith(expect.stringMatching('/public/locales/fr'))
       expect(props._nextI18Next.initialI18nStore)
         .toEqual({
@@ -111,7 +125,9 @@ describe('serverSideTranslations', () => {
           locales: ['en-US', 'fr-CA'],
         },
       } as UserConfig)
-      expect(fs.readdirSync).toHaveBeenCalledTimes(3)
+
+      expect(fs.existsSync).toHaveBeenCalledTimes(8)
+      expect(fs.readdirSync).toHaveBeenCalledTimes(6)
       expect(fs.readdirSync).toHaveBeenCalledWith(expect.stringMatching('/public/locales/en-US'))
       expect(fs.readdirSync).toHaveBeenCalledWith(expect.stringMatching('/public/locales/en'))
       expect(fs.readdirSync).toHaveBeenCalledWith(expect.stringMatching('/public/locales/fr'))
@@ -152,7 +168,9 @@ describe('serverSideTranslations', () => {
           locales: ['nl-BE', 'fr-BE', 'en-US'],
         },
       } as UserConfig)
-      expect(fs.readdirSync).toHaveBeenCalledTimes(2)
+
+      expect(fs.existsSync).toHaveBeenCalledTimes(6)
+      expect(fs.readdirSync).toHaveBeenCalledTimes(4)
       expect(fs.readdirSync).toHaveBeenCalledWith(expect.stringMatching('/public/locales/en-US'))
       expect(fs.readdirSync).toHaveBeenCalledWith(expect.stringMatching('/public/locales/fr'))
       expect(props._nextI18Next.initialI18nStore)
@@ -183,10 +201,11 @@ describe('serverSideTranslations', () => {
         },
       } as UserConfig, ['en-US', 'fr-BE', 'fr-BE'])
 
-      expect(fs.readdirSync).toHaveBeenCalledTimes(3)
-      expect(fs.readdirSync).toHaveBeenCalledWith(expect.stringMatching('/public/locales/de'))
-      expect(fs.readdirSync).toHaveBeenCalledWith(expect.stringMatching('/public/locales/en'))
-      expect(fs.readdirSync).toHaveBeenCalledWith(expect.stringMatching('/public/locales/fr'))
+      expect(fs.existsSync).toHaveBeenCalledTimes(7)
+      expect(fs.readdirSync).toHaveBeenCalledTimes(5)
+      expect(fs.readdirSync).toHaveBeenCalledWith(expect.stringMatching('/public/locales/de-CH'))
+      expect(fs.readdirSync).toHaveBeenCalledWith(expect.stringMatching('/public/locales/en-US'))
+      expect(fs.readdirSync).toHaveBeenCalledWith(expect.stringMatching('/public/locales/fr-BE'))
       expect(props._nextI18Next.initialI18nStore)
         .toEqual({
           'de-CH': {
@@ -224,7 +243,8 @@ describe('serverSideTranslations', () => {
         },
       } as UserConfig, false)
 
-      expect(fs.readdirSync).toHaveBeenCalledTimes(2)
+      expect(fs.existsSync).toHaveBeenCalledTimes(6)
+      expect(fs.readdirSync).toHaveBeenCalledTimes(4)
       expect(fs.readdirSync).toHaveBeenCalledWith(expect.stringMatching('/public/locales/de'))
       expect(fs.readdirSync).toHaveBeenCalledWith(expect.stringMatching('/public/locales/en'))
 


### PR DESCRIPTION
Fixes #1941

I did not understand why the `existsSync` mock returns `false` on the first call for all test cases in `serversideTranslations.tests.tsx`. Maybe it is related to #1302 and therefore obsolete? I have changed it to always return `true`, but since this change effects all tests, I'm not sure if this is the intended behaviour.

Additionally, it might make sense to "enable" server-side environment for all tests with something like
```
 beforeAll(() => {
      Object.assign(process, { browser: false })
      delete (global as any).window
    })
```
as is already the case for `createConfig.tests.tsx`. Currently `createConfig` is running in "client.side mode", which may not be the desired behavior for testing `getServerSideTranslations`? If this sounds reasonable to you @adrai, I can add changes to this PR or open another one - whichever you prefer.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)