### PR TITLE
Move i18next and react-i18next to peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Now our Next.js app is fully translatable!
 ### 1. Installation
 
 ```jsx
-yarn add next-i18next
+yarn add next-i18next react-i18next i18next
 ```
 
 You need to also have `react` and `next` installed.

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -9,10 +9,12 @@
     "start": "next start -p ${PORT:=3000}"
   },
   "dependencies": {
+    "i18next": "^21.9.1",
     "next": "12.2.5",
     "next-i18next": "12.0.1",
     "prop-types": "15.8.1",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "react-i18next": "^11.18.4"
   }
 }

--- a/examples/ssg/package.json
+++ b/examples/ssg/package.json
@@ -15,9 +15,11 @@
     "downloadLocales": "locize download --project-id=0842ada9-1d1d-4d48-ab27-08f6a132f558 --ver=latest --clean=true --path=./public/locales"
   },
   "dependencies": {
+    "i18next": "^21.9.1",
     "next": "12.2.5",
     "next-i18next": "12.0.1",
-    "next-language-detector": "1.0.2"
+    "next-language-detector": "1.0.2",
+    "react-i18next": "^11.18.4"
   },
   "devDependencies": {
     "eslint-config-next": "12.2.5",

--- a/package.json
+++ b/package.json
@@ -117,10 +117,12 @@
     "eslint-plugin-typescript-sort-keys": "^2.1.0",
     "gh-release": "6.0.4",
     "husky": "^3.0.0",
+    "i18next": "^21.9.1",
     "jest": "^26.6.3",
     "next": "^12.2.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-i18next": "^11.18.4",
     "start-server-and-test": "^1.14.0",
     "typescript": "^4.7.4"
   },
@@ -129,13 +131,13 @@
     "@types/hoist-non-react-statics": "^3.3.1",
     "core-js": "^3",
     "hoist-non-react-statics": "^3.3.2",
-    "i18next": "^21.9.1",
-    "i18next-fs-backend": "^1.1.5",
-    "react-i18next": "^11.18.4"
+    "i18next-fs-backend": "^1.1.5"
   },
   "peerDependencies": {
     "next": ">= 10.0.0",
-    "react": ">= 16.8.0"
+    "react": ">= 16.8.0",
+    "i18next": "^21.9.1",
+    "react-i18next": "^11.18.4"
   },
   "resolutions": {
     "i18next": ">=21.8.14",


### PR DESCRIPTION
This PR moves `i18next` and `react-i18next` to peerDependencies, so that consuming Yarn PnP projects aren't force to have multiple instances of `i18next` if they themselves depend on `react-i18next`.

After this PR, projects that use `next-i18next` will have to ensure they have `react-i18next` and `i18next` in their own dependencies: 

```sh
npm i react-i18next i18next
yarn add react-i18next i18next
```

See discussion in https://github.com/i18next/next-i18next/issues/1917

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] ~tests are included~
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)