### PR TITLE
QA improve checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: 📥 Install
+        run: npm install
+
+      - name: ESLint checks
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm test
+
+      - name: E2E tests
+        run: npm run test:e2e
+
+      - name: Build next-i18next
+        run: npm run build
+
+      - name: Check dist for ecmascript compliance
+        run: npm run check-dist
+
+      - name: Check size limits
+        run: npm run check-size
+

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -1,13 +1,18 @@
 // @ts-check
 
-const fullEsmMaxSize = "10KB";
-const fullCjsMaxSize = "10KB";
+const fullEsmMaxSize = "23KB";
+const fullCjsMaxSize = "46KB";
+
+const modifyWebpackConfig = config => {
+  config.resolve = {};
+  config.resolve.fallback = { "path": false, "fs": false };
+}
 
 /**
  * Will ensure esm tree-shakeability and total size are within expectations.
  *
  * @link https://github.com/ai/size-limit/
- * @type {{name: string, path: string[], limit: string, import?: string, webpack?: boolean}[]}
+ * @type {{name: string, path: string[], limit: string, import?: string, webpack?: boolean, modifyWebpackConfig: any}[]}
  */
 module.exports = [
   // ###################################################
@@ -18,6 +23,7 @@ module.exports = [
     path: ["dist/esm/index.js"],
     import: "*",
     limit: fullEsmMaxSize,
+    modifyWebpackConfig,
   },
   // ###################################################
   // Commonjs full bundle
@@ -28,5 +34,6 @@ module.exports = [
     import: "*",
     webpack: true,
     limit: fullCjsMaxSize,
+    modifyWebpackConfig,
   }
 ];

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -1,0 +1,32 @@
+// @ts-check
+
+const fullEsmMaxSize = "10KB";
+const fullCjsMaxSize = "10KB";
+
+/**
+ * Will ensure esm tree-shakeability and total size are within expectations.
+ *
+ * @link https://github.com/ai/size-limit/
+ * @type {{name: string, path: string[], limit: string, import?: string, webpack?: boolean}[]}
+ */
+module.exports = [
+  // ###################################################
+  // ESM full bundle
+  // ###################################################
+  {
+    name: "ESM (import everything *)",
+    path: ["dist/esm/index.js"],
+    import: "*",
+    limit: fullEsmMaxSize,
+  },
+  // ###################################################
+  // Commonjs full bundle
+  // ###################################################
+  {
+    name: "CJS (require everything *)",
+    path: ["dist/commonjs/index.js"],
+    import: "*",
+    webpack: true,
+    limit: fullCjsMaxSize,
+  }
+];

--- a/package.json
+++ b/package.json
@@ -66,9 +66,9 @@
     "postversion": "git push && git push --tags && npm run release",
     "release": "gh-release",
     "check-size": "size-limit",
-    "check-dist": "run-s check-dist-esm check-dist-cjs",
-    "check-dist-cjs": "es-check --not './dist/commonjs/*.map.js' --not './dist/commonjs/createClient/package.json' -v es2017 './dist/commonjs/**/*'",
-    "check-dist-esm": "es-check --not './dist/esm/*.map.js' --not './dist/esm/createClient/package.json' -v es2017 --module './dist/esm/**/*'"
+    "check-dist": "run-s check-dist:*",
+    "check-dist:browser-cjs": "es-check --not 'dist/**/*.map.js,dist/commonjs/createClient/package.json,dist/commonjs/**node**.js,dist/commonjs/serverSideTranslations.js' -v es2017 './dist/commonjs/**/*'",
+    "check-dist:browser-esm": "es-check --not 'dist/**/*.map.js,dist/esm/createClient/package.json,dist/**node**.js,dist/esm/serverSideTranslations.js' -v es2017 --module './dist/esm/**/*'"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -64,8 +64,11 @@
     "contributors:generate": "all-contributors generate",
     "preversion": "npm run test && npm run build && git push",
     "postversion": "git push && git push --tags && npm run release",
-    "release": "gh-release"
-  },
+    "release": "gh-release",
+    "check-size": "size-limit",
+    "check-dist": "run-s check-dist-esm check-dist-cjs",
+    "check-dist-cjs": "es-check --not './dist/commonjs/*.map.js' --not './dist/commonjs/createClient/package.json' -v es2017 './dist/commonjs/**/*'",
+    "check-dist-esm": "es-check --not './dist/esm/*.map.js' --not './dist/esm/createClient/package.json' -v es2017 --module './dist/esm/**/*'"},
   "husky": {
     "hooks": {
       "pre-commit": "npm run lint"
@@ -93,6 +96,9 @@
     "@babel/preset-env": "^7.18.10",
     "@babel/preset-react": "^7.18.6",
     "@babel/preset-typescript": "^7.18.6",
+    "@size-limit/file": "^8.1.0",
+    "@size-limit/webpack": "^8.1.0",
+    "@size-limit/webpack-why": "8.1.0",
     "@testing-library/react": "^13.3.0",
     "@types/i18next-fs-backend": "^1.1.2",
     "@types/jest": "^28.1.7",
@@ -108,6 +114,7 @@
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "bundlesize": "^0.18.1",
     "cypress": "^9.1.1",
+    "es-check": "^7.0.1",
     "eslint": "^8.22.0",
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-import": "^2.26.0",
@@ -119,10 +126,13 @@
     "husky": "^3.0.0",
     "jest": "^26.6.3",
     "next": "^12.2.5",
+    "npm-run-all": "^4.1.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "start-server-and-test": "^1.14.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "size-limit": "8.1.0",
+    "webpack": "5.74.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.18.9",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "postversion": "git push && git push --tags && npm run release",
     "release": "gh-release",
     "check-size": "size-limit",
+    "analyze-size:why": "size-limit --why",
     "check-dist": "run-s check-dist:*",
     "check-dist:browser-cjs": "es-check --not 'dist/**/*.map.js,dist/commonjs/createClient/package.json,dist/commonjs/**node**.js,dist/commonjs/serverSideTranslations.js' -v es2017 './dist/commonjs/**/*'",
     "check-dist:browser-esm": "es-check --not 'dist/**/*.map.js,dist/esm/createClient/package.json,dist/**node**.js,dist/esm/serverSideTranslations.js' -v es2017 --module './dist/esm/**/*'"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "check-size": "size-limit",
     "check-dist": "run-s check-dist-esm check-dist-cjs",
     "check-dist-cjs": "es-check --not './dist/commonjs/*.map.js' --not './dist/commonjs/createClient/package.json' -v es2017 './dist/commonjs/**/*'",
-    "check-dist-esm": "es-check --not './dist/esm/*.map.js' --not './dist/esm/createClient/package.json' -v es2017 --module './dist/esm/**/*'"},
+    "check-dist-esm": "es-check --not './dist/esm/*.map.js' --not './dist/esm/createClient/package.json' -v es2017 --module './dist/esm/**/*'"
+  },
   "husky": {
     "hooks": {
       "pre-commit": "npm run lint"


### PR DESCRIPTION
I'd like to rework the (dual) packaging if possible. That is a continuation of https://github.com/i18next/next-i18next/pull/1966#issuecomment-1285449857.

But before of that, I would like to ensure I have a correct baseline. So I introduced few things

- a github action
- a size-limit script (with webpack to follow possible tree-shakability regressions)
- an ecmascript check (to prevent regressions in the build)

The size-limit might obsolete in bundlesize, I might remove later on.

Locally

```bash
npm install
npm run build
npm run check-size
npm run check-dist
```

Want to analyze the differences in bundles (esm, cjs):

```bash
npm run analyze-size
```

Will open the 

![image](https://user-images.githubusercontent.com/259798/196990549-d2006f80-28f8-4359-abfe-078653e4bdc3.png)


We can already see that cjs does not tree-shake. Big opportunity cause by default nextjs will use it rather than esm. 