### PR TITLE
CI fix github action event trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,6 @@
 name: CI
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
+on: [push]
 
 jobs:
   test:


### PR DESCRIPTION
Will avoid triggering twice the new gha workflow.

setup/node won't work yet as it lacks the lock file. It will be tackled in https://github.com/i18next/next-i18next/pull/1970