### PR TITLE
chore(size-limit): check also for next-app dist folder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Build next-i18next
         run: npm run build
 
+      - name: Build examples
+        run: npm run build:examples
+
       - name: Check dist for ecmascript compliance
         run: npm run check-dist
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,11 @@ jobs:
       - name: Build examples
         run: npm run build:examples
 
-      - name: Check dist for ecmascript compliance
-        run: npm run check-dist
-
       - name: Check size limits
         run: npm run check-size
+
+      - name: Check dist for ecmascript compliance
+        run: npm run check-dist
 
       - name: Unit tests
         run: npm test

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -3,6 +3,38 @@
 const fullEsmMaxSize = "23KB";
 const fullCjsMaxSize = "46KB";
 
+const getSimpleExamplePageLimits = () => {
+  const dir = './examples/simple/.next'
+  let manifest;
+  try {
+    manifest = require(`${dir}/build-manifest.json`);
+  } catch (e) {
+    throw new Error(
+        'Cannot find a NextJs build folder, did you forget to run build:examples ?'
+    );
+  }
+  const limitCfg = {
+    defaultSize: '90kb',
+    pages: {
+      '/': '85kb',
+      '/404': '90kb',
+      '/_app': '100kb',
+      '/_error': '80Kb',
+      '/second-page': '85Kb'
+    },
+  };
+  let pageLimits = [];
+  for (const [uri, paths] of Object.entries(manifest.pages)) {
+    pageLimits.push({
+      name: `Example app: page '${uri}'`,
+      limit: limitCfg.pages?.[uri] ?? limitCfg.defaultSize,
+      webpack: false,
+      path: paths.map(p => `${dir}/${p}`)
+    });
+  }
+  return pageLimits;
+}
+
 const modifyWebpackConfig = config => {
   config.resolve = {};
   config.resolve.fallback = { "path": false, "fs": false };
@@ -16,7 +48,7 @@ const modifyWebpackConfig = config => {
  */
 module.exports = [
   // ###################################################
-  // ESM full bundle
+  // Dist ESM full bundle
   // ###################################################
   {
     name: "ESM (import everything *)",
@@ -26,7 +58,7 @@ module.exports = [
     modifyWebpackConfig,
   },
   // ###################################################
-  // Commonjs full bundle
+  // Fist commonjs full bundle
   // ###################################################
   {
     name: "CJS (require everything *)",
@@ -35,5 +67,9 @@ module.exports = [
     webpack: true,
     limit: fullCjsMaxSize,
     modifyWebpackConfig,
-  }
+  },
+  // ###################################################
+  // Example apps
+  // ###################################################
+  ...getSimpleExamplePageLimits(),
 ];

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "build:esm": "BABEL_ENV=esm babel src --extensions '.ts,.tsx' --out-dir dist/esm --copy-files",
     "build:types": "tsc --noEmit false --declaration --emitDeclarationOnly --outDir dist/types",
     "build": "npm run clean && npm run build:cjs && npm run build:es && npm run build:esm && npm run build:types",
+    "build:examples": "run-s build:example:*",
     "build:example:simple": "cd examples/simple && npm run build",
     "build:example:ssg": "cd examples/ssg && npm run build",
     "install:example:simple": "cd examples/simple && npm install",
@@ -131,9 +132,9 @@
     "npm-run-all": "^4.1.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "size-limit": "8.1.0",
     "start-server-and-test": "^1.14.0",
     "typescript": "^4.7.4",
-    "size-limit": "8.1.0",
     "webpack": "5.74.0"
   },
   "dependencies": {


### PR DESCRIPTION
I know we already have bundlesize, but I'd like to expand the size-checks to the example app with size-limit. I'd like to have fine grain control on side-effects of publish improvements.

Same method used as in https://github.com/i18next/next-i18next/pull/1969

Running 

```bash
npm run check-size
```

Will give

![image](https://user-images.githubusercontent.com/259798/197025592-4aba83db-a859-456a-9d3a-aec6a9f0cb63.png)


