### PR TITLE
Drop node 12 support (next major)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## next
+
+- breaking: drop node 12.x support, requires 14.x. Recommended minimum to `^14.13.1`.
+
 ## 12.1.0
 
 - fix: appWithTranslation re-renders _app when the locale is changed (#1954)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "types": "dist/types/types.d.ts",
   "license": "MIT",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "description": "The easiest way to translate your NextJs apps.",
   "keywords": [


### PR DESCRIPTION
I'd like to bump the minimum node version to 14.x (12.x is not maintained).

I feel it might avoid issue if this PR is merged: https://github.com/i18next/next-i18next/pull/1973

## Version

Next major version (13). 

Makes sense to merge along https://github.com/i18next/next-i18next/pull/1966  as both will bump a major.

## Note

I've been pretty lax on version (<14). In practice, I would recommended 14.13.1 minimum. But it's fine to not enforce it. (this helps when moving to pure esm)