### PR TITLE
feat(example): add type augmentation for dictionnaries

### DIFF
--- a/examples/simple/pages/second-page.tsx
+++ b/examples/simple/pages/second-page.tsx
@@ -13,17 +13,17 @@ type Props = {
 
 const SecondPage = (_props: InferGetStaticPropsType<typeof getStaticProps>) => {
 
-  const { t } = useTranslation('second-page')
+  const { t } = useTranslation(['common', 'second-page'])
 
   return (
     <>
       <main>
-        <Header heading={t('h1')} title={t('title')} />
+        <Header heading={t('second-page:h1')} title={t('second-page:title')} />
         <Link href='/'>
           <button
             type='button'
           >
-            {t('back-to-home')}
+            {t('second-page:back-to-home')}
           </button>
         </Link>
       </main>

--- a/examples/simple/types.d/react-i18next.d.ts
+++ b/examples/simple/types.d/react-i18next.d.ts
@@ -1,0 +1,24 @@
+/**
+ * Types augmentation for translation keys to allow to typecheck
+ * and suggesting keys to the t function. In case it's too slow
+ * you can opt out by commenting the following code.
+ * @link https://react.i18next.com/latest/typescript
+ */
+import 'react-i18next'
+
+import type common from '../public/locales/en/common.json'
+import type footer from '../public/locales/en/footer.json'
+import type secondPage from '../public/locales/en/second-page.json'
+
+interface I18nNamespaces {
+    common: typeof common
+    footer: typeof footer
+    'second-page': typeof secondPage
+}
+
+declare module 'react-i18next' {
+  interface CustomTypeOptions {
+    defaultNS: 'common'
+    resources: I18nNamespaces
+  }
+}


### PR DESCRIPTION
I'd like to add type augmentation in the simple example.

That might help to detect anomalies when upgrading to react-i18next 12 / i18next 22. Cause the usage will slightly change. 

I'll be happy to include the changes when working on https://github.com/i18next/next-i18next/pull/1966.



