### PR TITLE
Drop support for nextjs < 12 and react < 17.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## next
 
-- breaking: drop node 12.x support, requires 14.x. Recommended minimum to `^14.13.1`.
+- breaking: drop nextjs < 12.0.0 and react < 17.0.2 in [#1983](https://github.com/i18next/next-i18next/pull/1983) 
+- breaking: drop node 12.x support, requires 14.x. Recommended minimum to `^14.13.1`, 
+  see [#1974](https://github.com/i18next/next-i18next/pull/1974)
 
 ## 12.1.0
 

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "react-i18next": "^11.18.4"
   },
   "peerDependencies": {
-    "next": ">= 10.0.0",
-    "react": ">= 16.8.0"
+    "next": ">= 12.0.0",
+    "react": ">= 17.0.2"
   }
 }


### PR DESCRIPTION
For next major, I suggest to drop those.

I've upgraded react to 17 to align with nextjs 12.0.0 - https://github.com/vercel/next.js/blob/8a450db14a1b29d506ec86df1a002bc525ab0da7/packages/next/package.json#L117