### PR TITLE
Examples should use git install (do not merge)

### DIFF
--- a/examples/simple/components/Footer.tsx
+++ b/examples/simple/components/Footer.tsx
@@ -3,21 +3,17 @@ import { useTranslation, Trans } from 'next-i18next'
 import type { FC } from 'react'
 
 export const Footer: FC = () => {
-
   const { t } = useTranslation('footer')
+  const { version = 'git' } = pkg as unknown as { version: string }
 
   return (
     <footer>
-      <p>
-        {t('description')}
-      </p>
-      <p>
-        next-i18next v
-        {pkg.version}
-      </p>
-      <p style={{ fontSize: 'smaller', fontStyle: 'italic', marginTop: 20 }}>
+      <p>{t('description')}</p>
+      <p>next-i18next v{version}</p>
+      <p style={{fontSize: 'smaller', fontStyle: 'italic', marginTop: 20}}>
         <Trans i18nKey='helpLocize' t={t}>
-          With using <a href='https://locize.com' target='_new'>locize</a> you directly support the future of <a href='https://www.i18next.com' target='_new'>i18next</a>.
+           With using <a href='https://locize.com' target='_new'>locize</a> you directly support the future
+           of <a href='https://www.i18next.com' target='_new'>i18next</a>.
         </Trans>
       </p>
     </footer>

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "i18next": "22.0.4",
     "next": "13.0.2",
-    "next-i18next": "12.1.0",
+    "next-i18next": "file:../..",
     "react": "18.2.0",
     "react-i18next": "12.0.0",
     "react-dom": "18.2.0"

--- a/examples/simple/pages/_app.tsx
+++ b/examples/simple/pages/_app.tsx
@@ -1,10 +1,10 @@
 import type { AppProps } from 'next/app'
 import { appWithTranslation } from 'next-i18next'
-// import nextI18NextConfig from '../next-i18next.config.js'
+import nextI18NextConfig from '../next-i18next.config.js'
 
 const MyApp = ({ Component, pageProps }: AppProps) => (
   <Component {...pageProps} />
 )
 
 // https://github.com/i18next/next-i18next#unserialisable-configs
-export default appWithTranslation(MyApp/*, nextI18NextConfig */)
+export default appWithTranslation(MyApp, nextI18NextConfig)

--- a/examples/simple/pages/index.tsx
+++ b/examples/simple/pages/index.tsx
@@ -4,6 +4,7 @@ import type { GetStaticProps, InferGetStaticPropsType } from 'next'
 
 import { useTranslation, Trans } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import nextI18NextConfig from '../next-i18next.config.js'
 
 import { Header } from '../components/Header'
 import { Footer } from '../components/Footer'
@@ -85,7 +86,7 @@ const Homepage = (_props: InferGetStaticPropsType<typeof getStaticProps>) => {
 // or getServerSideProps: GetServerSideProps<Props> = async ({ locale })
 export const getStaticProps: GetStaticProps<Props> = async ({ locale }) => ({
   props: {
-    ...await serverSideTranslations(locale ?? 'en', ['common', 'footer']),
+    ...await serverSideTranslations(locale ?? 'en', ['common', 'footer'], nextI18NextConfig),
   },
 })
 

--- a/examples/simple/pages/second-page.tsx
+++ b/examples/simple/pages/second-page.tsx
@@ -4,6 +4,8 @@ import type { GetServerSideProps, InferGetServerSidePropsType } from 'next'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
+import nextI18NextConfig from '../next-i18next.config.js'
+
 import { Header } from '../components/Header'
 import { Footer } from '../components/Footer'
 
@@ -34,7 +36,7 @@ const SecondPage = (_props: InferGetServerSidePropsType<typeof getServerSideProp
 
 export const getServerSideProps: GetServerSideProps<Props> = async ({ locale }) => ({
   props: {
-    ...await serverSideTranslations(locale ?? 'en', ['second-page', 'footer']),
+    ...await serverSideTranslations(locale ?? 'en', ['second-page', 'footer'], nextI18NextConfig),
   },
 })
 

--- a/examples/ssg/lib/getStatic.js
+++ b/examples/ssg/lib/getStatic.js
@@ -16,7 +16,7 @@ export const getStaticPaths = () => ({
 export const getI18nProps = async (ctx, ns = ['common']) => {
   const locale = ctx?.params?.locale
   let props = {
-    ...(await serverSideTranslations(locale, ns)),
+    ...(await serverSideTranslations(locale, ns, i18nextConfig)),
   }
   return props
 }

--- a/examples/ssg/package.json
+++ b/examples/ssg/package.json
@@ -15,9 +15,9 @@
     "downloadLocales": "locize download --project-id=0842ada9-1d1d-4d48-ab27-08f6a132f558 --ver=latest --clean=true --path=./public/locales"
   },
   "dependencies": {
-    "i18next": "22.0.3",
-    "next": "13.0.0",
-    "next-i18next": "12.1.0",
+    "i18next": "22.0.4",
+    "next": "13.0.2",
+    "next-i18next": "file:../..",
     "next-language-detector": "1.0.2",
     "react": "18.2.0",
     "react-i18next": "12.0.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "analyze-size:why": "size-limit --why",
     "check-dist": "run-s check-dist:*",
     "check-dist:browser-cjs": "es-check --not 'dist/**/*.map.js,dist/commonjs/createClient/package.json,dist/commonjs/**node**.js,dist/commonjs/serverSideTranslations.js' -v es2017 './dist/commonjs/**/*'",
-    "check-dist:browser-esm": "es-check --not 'dist/**/*.map.js,dist/esm/createClient/package.json,dist/**node**.js,dist/esm/serverSideTranslations.js' -v es2017 --module './dist/esm/**/*'"
+    "check-dist:browser-esm": "es-check --not 'dist/**/*.map.js,dist/esm/createClient/package.json,dist/**node**.js,dist/esm/serverSideTranslations.js' -v es2017 --module './dist/esm/**/*'",
+    "nuke:install": "rimraf '**/node_modules' '**/package-lock.json'"
   },
   "husky": {
     "hooks": {

--- a/src/serverSideTranslations.ts
+++ b/src/serverSideTranslations.ts
@@ -23,8 +23,10 @@ export const serverSideTranslations = async (
 
   let userConfig = configOverride
 
-  if (!userConfig && fs.existsSync(path.resolve(DEFAULT_CONFIG_PATH))) {
-    userConfig = await import(path.resolve(DEFAULT_CONFIG_PATH))
+  const configFile = path.resolve(DEFAULT_CONFIG_PATH)
+
+  if (!userConfig && fs.existsSync(configFile)) {
+    userConfig = await import(configFile)
   }
 
   if (userConfig === null) {


### PR DESCRIPTION
When working on #1998 and #1997, I feel it's useful to be able to test from the git build rather than installing the published version (possibly old)

IMHO, we should move out from npm to yarn 3+ or pnpm 7+ and rework the directory structure. Why ? Npm and workspaces aren't yet there when we have to deal with monorepos (ie: workspace protocol rather than files, versioning, isolation...).
 