### PR TITLE
ci: fix debug runner step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,11 @@ jobs:
       - name: Install Examples
         run: npm run install:examples
 
-      - name: ⓘ Debug runner
+      - name: ⓘ Debug next-i18next installation
+        shell: bash
+        run: npx envinfo --binaries --npmPackages
+
+      - name: ⓘ Debug example/simple installation
         shell: bash
         run: npx envinfo --binaries --npmPackages
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: ⓘ Debug runner
         shell: bash
-        run: npx -y envinfo --binaries --npmPackages
+        run: npx envinfo --binaries --npmPackages
 
       - name: ESLint checks
         run: npm run lint


### PR DESCRIPTION
Fix debug runner step and output examples/simple output.  

Why needed ? 

- test-e2e works on ci, not on my local machine. without lock file (choice made before), I'd like to exclude resolutions problems (reproducibility).

In the future I feel we would benefit to commit lock files (or at least for the base package).

See output in https://github.com/i18next/next-i18next/actions/runs/3410769134/jobs/5674130702

![image](https://user-images.githubusercontent.com/259798/200323572-a3041aa8-d658-4665-bd62-e1f0c7555fc6.png)
