### PR TITLE
chore: remove bundlesize in favour of size-limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "example:ssg": "npm run build && cp -r dist examples/ssg/node_modules/next-i18next && cd examples/ssg && npm run dev",
     "example:ssg:prod": "npm run build:example:ssg && cd examples/ssg && npm run start",
     "cypress": "cypress run --config-file cypress/cypress.json",
-    "test": "npm-run-all -s check-types clean build build:example:simple && bundlesize && NODE_ENV=test jest --maxWorkers=1 --silent",
+    "test": "npm-run-all -s check-types clean build build:example:simple && NODE_ENV=test jest --maxWorkers=1 --silent",
     "test:e2e": "start-server-and-test 'cd examples/simple && npm run start' 3000 'npm run cypress'",
     "contributors:check": "all-contributors check",
     "contributors:add": "all-contributors add",
@@ -78,20 +78,6 @@
       "pre-commit": "npm run lint"
     }
   },
-  "bundlesize": [
-    {
-      "path": "./examples/simple/.next/static/chunks/*.js",
-      "maxSize": "50 kB"
-    },
-    {
-      "path": "./examples/simple/.next/static/chunks/main*.js",
-      "maxSize": "35 kB"
-    },
-    {
-      "path": "./examples/simple/.next/static/chunks/webpack*.js",
-      "maxSize": "770 B"
-    }
-  ],
   "devDependencies": {
     "@babel/cli": "^7.18.10",
     "@babel/core": "^7.18.10",
@@ -115,7 +101,6 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-plugin-add-module-exports": "^1.0.4",
     "babel-plugin-transform-async-to-generator": "^6.24.1",
-    "bundlesize": "^0.18.1",
     "cypress": "^9.1.1",
     "es-check": "^7.0.1",
     "eslint": "^8.22.0",


### PR DESCRIPTION
I'd like to remove bundlesize. Why ?

- We introduced size-limit (and npm run check-size in the https://github.com/i18next/next-i18next/pull/1969 and subsequent PR's). I feel it's an easier tool.
- Bundlesize is relying on itorb (node-gyp), this makes install slower as it has to be compiled for no so much benefits (minus 15 seconds in install). 
- I also separate check-size from test-e2e. (I feel it's clearer IMO, but open any changes here)


```
npm why iltorb
iltorb@2.4.5 extraneous
node_modules/iltorb
  iltorb@"^2.4.3" from brotli-size@0.1.0
  node_modules/brotli-size
    brotli-size@"0.1.0" from bundlesize@0.18.1
    node_modules/bundlesize

```

