### PR TITLE
ci: add node-18 lts checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 14.x]
+        node-version: [18.x, 16.x, 14.x]
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Node 18 is LTS now, let's check