### PR TITLE
chore(examples): lock nextjs version

### DIFF
--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "i18next": "^22.0.4",
-    "next": "^13.0.2",
+    "next": "13.0.2",
     "next-i18next": "file:../..",
     "react": "^18.2.0",
     "react-i18next": "^12.0.0",
@@ -23,7 +23,7 @@
     "@types/node": "^18.11.3",
     "@types/react": "^18.0.21",
     "@types/react-dom": "^18.0.6",
-    "eslint-config-next": "^13.0.2",
+    "eslint-config-next": "13.0.2",
     "rimraf": "^3.0.2",
     "picocolors": "^1.0.0",
     "typescript": "^4.8.4"

--- a/examples/ssg/package.json
+++ b/examples/ssg/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "i18next": "^22.0.3",
-    "next": "^13.0.2",
+    "next": "13.0.2",
     "next-i18next": "file:../..",
     "next-language-detector": "^1.0.2",
     "react": "^18.2.0",
@@ -25,7 +25,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "eslint-config-next": "^13.0.2",
+    "eslint-config-next": "13.0.2",
     "http-server": "14.1.1",
     "locize-cli": "7.12.7",
     "rimraf": "^3.0.2"


### PR DESCRIPTION
Due to a regression in swcMinify in nextjs 13.0.3, our (e2e) size limit checks fail. See https://github.com/vercel/next.js/issues/42813

The issue have since been fixed but not released.

As we don't use lock for examples, it's difficult to avoid having that issue to pop up from time to time (making the ci fail for no *real* reason). I locked the versions of nextjs (till we have better solution). good tradeoff

