### PR TITLE
I18next peer dep to 22.0.6

### DIFF
--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -12,8 +12,8 @@
     "nuke:install": "rimraf ./node_modules ./package-lock.json"
   },
   "dependencies": {
-    "i18next": "^22.0.5",
-    "next": "13.0.2",
+    "i18next": "^22.0.6",
+    "next": "13.0.4",
     "next-i18next": "file:../..",
     "react": "^18.2.0",
     "react-i18next": "^12.0.0",

--- a/examples/ssg/package.json
+++ b/examples/ssg/package.json
@@ -16,8 +16,8 @@
     "clean": "rimraf .next out"
   },
   "dependencies": {
-    "i18next": "^22.0.5",
-    "next": "13.0.2",
+    "i18next": "^22.0.6",
+    "next": "13.0.4",
     "next-i18next": "file:../..",
     "next-language-detector": "^1.0.2",
     "react": "^18.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "eslint-plugin-typescript-sort-keys": "^2.1.0",
         "gh-release": "6.0.4",
         "husky": "^8.0.2",
-        "i18next": "^22.0.5",
+        "i18next": "^22.0.6",
         "jest": "^29.3.1",
         "jest-environment-jsdom": "^29.3.1",
         "next": "^13.0.2",
@@ -82,7 +82,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "i18next": "^22.0.5",
+        "i18next": "^22.0.6",
         "next": ">= 12.0.0",
         "react": ">= 17.0.2",
         "react-i18next": "^12.0.0"
@@ -2034,9 +2034,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.17.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+      "version": "13.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
+      "integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -8033,9 +8033,9 @@
       }
     },
     "node_modules/eslint/node_modules/globals": {
-      "version": "13.17.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+      "version": "13.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
+      "integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -9368,9 +9368,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "22.0.5",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-22.0.5.tgz",
-      "integrity": "sha512-N2AXKCLHzv1ClfLqiwbAPJHClovfRv9iplySiZ/S3LfQ7PNjkVEkVpFbhCXDsPhQd6kLp6DKjbzpowniE8Mdiw==",
+      "version": "22.0.6",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-22.0.6.tgz",
+      "integrity": "sha512-RlreNGoPIdDP4QG+qSA9PxZKGwlzmcozbI9ObI6+OyUa/Rp0EjZZA9ubyBjw887zVNZsC+7FI3sXX8oiTzAfig==",
       "dev": true,
       "funding": [
         {
@@ -14965,9 +14965,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.10",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.0",
@@ -18828,9 +18828,9 @@
       },
       "dependencies": {
         "globals": {
-          "version": "13.17.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-          "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+          "version": "13.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
+          "integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -23221,9 +23221,9 @@
           }
         },
         "globals": {
-          "version": "13.17.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-          "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+          "version": "13.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
+          "integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -24445,9 +24445,9 @@
       "dev": true
     },
     "i18next": {
-      "version": "22.0.5",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-22.0.5.tgz",
-      "integrity": "sha512-N2AXKCLHzv1ClfLqiwbAPJHClovfRv9iplySiZ/S3LfQ7PNjkVEkVpFbhCXDsPhQd6kLp6DKjbzpowniE8Mdiw==",
+      "version": "22.0.6",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-22.0.6.tgz",
+      "integrity": "sha512-RlreNGoPIdDP4QG+qSA9PxZKGwlzmcozbI9ObI6+OyUa/Rp0EjZZA9ubyBjw887zVNZsC+7FI3sXX8oiTzAfig==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.17.2"
@@ -28552,9 +28552,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.10",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regenerator-transform": {
       "version": "0.15.0",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "eslint-plugin-typescript-sort-keys": "^2.1.0",
     "gh-release": "6.0.4",
     "husky": "^8.0.2",
-    "i18next": "^22.0.5",
+    "i18next": "^22.0.6",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
     "next": "^13.0.2",
@@ -133,7 +133,7 @@
     "i18next-fs-backend": "^2.0.0"
   },
   "peerDependencies": {
-    "i18next": "^22.0.5",
+    "i18next": "^22.0.6",
     "next": ">= 12.0.0",
     "react": ">= 17.0.2",
     "react-i18next": "^12.0.0"


### PR DESCRIPTION
Update minimumin i18next version to latest: https://github.com/i18next/i18next/releases/tag/v22.0.6. Also updated react to 13.0.4 in examples as the swcMinify regression has gone https://github.com/belgattitude/nextjs-monorepo-example/pull/2896