### PR TITLE
Upgrading: clarify keys typings update

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -26,7 +26,7 @@ If you're using typescript type augmentation for your locale keys, they've been 
 Rename `@types/react-i18next.d.ts` to `@types/i18next.d.ts` and be sure to update the imports:
 
 ```typescript
-import 'i18next';
+import 'i18next'; // before v13.0.0 -> import 'react-i18next';
 import type common from '../public/locales/en/common.json';
 import type other from '../public/locales/en/other.json';
 
@@ -34,6 +34,7 @@ interface I18nNamespaces {
   common: typeof common,
   other: typeof other,
 }
+// before v13.0.0 -> declare module 'react-i18next'
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'common',


### PR DESCRIPTION
In the light of https://github.com/i18next/next-i18next/discussions/2029.

@adrai I would like to release the v13.0.0, what's your feeling about it ? 

PS: The only thing was: https://github.com/i18next/next-i18next/pull/2018#issuecomment-1313565603 but I guess we can go on.