### PR TITLE
chore(lock): freshen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,15 +10,19 @@
       "funding": [
         {
           "type": "individual",
-          "url": "https://locize.com"
-        },
-        {
-          "type": "individual",
           "url": "https://locize.com/i18next.html"
         },
         {
           "type": "individual",
           "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://github.com/belgattitude"
         }
       ],
       "license": "MIT",


### PR DESCRIPTION
Lock wasn't refreshed. Now done.

PS: in my experience there's no "easy" way to ensure this with npm in the ci action (`npm ci` + node 14+16+18 and cache). I'll see what I can do later on. PNPM/Yarn3+ clears that out (see also https://github.com/belgattitude/compare-package-managers).