### PR TITLE
ci: run workflow on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
     paths-ignore:
       - 'docs/**'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,9 @@ on:
     branches:
       - master
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
+    types: [opened, synchronize, reopened]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,11 @@ on:
     branches:
       - master
   pull_request:
-    types: [opened, synchronize, reopened]
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - '**'
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   test:


### PR DESCRIPTION
Attempt to allow PR from forks to run workflows after synchronization.

When approved workflows runs from forks, but any subsequent commits does not trigger workflows anymore. Let's try https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/

Example: https://github.com/i18next/next-i18next/pull/2025#issuecomment-1329335943

First commit after approval

![image](https://user-images.githubusercontent.com/259798/204326782-90b7dcfb-1570-42a9-a87f-6a0ed775f341.png)


Subsequent commits:

![image](https://user-images.githubusercontent.com/259798/204326926-ba0518ba-acbb-4b3f-981f-360dfbd448f7.png)
