### PR TITLE
fix(example): align nextjs version and update

### DIFF
--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "i18next": "^22.0.6",
-    "next": "13.0.6",
-    "next-i18next": "13.0.0",
+    "next": "^13.0.6",
+    "next-i18next": "^13.0.0",
     "react": "^18.2.0",
     "react-i18next": "^12.0.0",
     "react-dom": "^18.2.0"
@@ -23,7 +23,7 @@
     "@types/node": "^18.11.3",
     "@types/react": "^18.0.21",
     "@types/react-dom": "^18.0.6",
-    "eslint-config-next": "13.0.2",
+    "eslint-config-next": "^13.0.6",
     "rimraf": "^3.0.2",
     "picocolors": "^1.0.0",
     "typescript": "^4.9.3"

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -12,11 +12,11 @@
     "nuke:install": "rimraf ./node_modules ./package-lock.json"
   },
   "dependencies": {
-    "i18next": "^22.0.6",
+    "i18next": "^22.4.1",
     "next": "^13.0.6",
     "next-i18next": "^13.0.0",
     "react": "^18.2.0",
-    "react-i18next": "^12.0.0",
+    "react-i18next": "^12.1.1",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
@@ -26,6 +26,6 @@
     "eslint-config-next": "^13.0.6",
     "rimraf": "^3.0.2",
     "picocolors": "^1.0.0",
-    "typescript": "^4.9.3"
+    "typescript": "^4.9.4"
   }
 }

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -12,7 +12,7 @@
     "nuke:install": "rimraf ./node_modules ./package-lock.json"
   },
   "dependencies": {
-    "i18next": "^22.4.1",
+    "i18next": "22.3.0",
     "next": "^13.0.6",
     "next-i18next": "^13.0.0",
     "react": "^18.2.0",

--- a/examples/ssg/package.json
+++ b/examples/ssg/package.json
@@ -16,16 +16,16 @@
     "clean": "rimraf .next out"
   },
   "dependencies": {
-    "i18next": "^22.0.6",
+    "i18next": "22.3.0",
     "next": "13.0.6",
     "next-i18next": "13.0.0",
     "next-language-detector": "^1.0.2",
     "react": "^18.2.0",
-    "react-i18next": "^12.0.0",
+    "react-i18next": "^12.1.1",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "eslint-config-next": "13.0.2",
+    "eslint-config-next": "13.0.6",
     "http-server": "14.1.1",
     "locize-cli": "7.12.7",
     "rimraf": "^3.0.2"


### PR DESCRIPTION
A small update and alignment of deps for simple example

**Warning**

There's an issue regarding latest i18next. So I locked it to 22.3.0 

![image](https://user-images.githubusercontent.com/259798/206993743-2a7f5788-095d-4f02-a18f-a411805e7d6b.png)
