### PR TITLE
Examples updated to latest i18next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ### Fix
 
 - Fix missing `i18n.localeDetection` in UserConfig, see [#2057](https://github.com/i18next/next-i18next/pull/2057).
+- Update examples to latest i18next in [#2058](https://github.com/i18next/next-i18next/pull/2058)
+
+**Caution**
+
+If you're experiencing typecheck errors regarding keys: ensure `i18next` is at least `^22.4.3` in your
+package.json (then run install), see [#2058](https://github.com/i18next/next-i18next/pull/2058).
+
 
 ## 13.0.0
 

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -12,7 +12,7 @@
     "nuke:install": "rimraf ./node_modules ./package-lock.json"
   },
   "dependencies": {
-    "i18next": "22.3.0",
+    "i18next": "22.4.3",
     "next": "^13.0.6",
     "next-i18next": "^13.0.0",
     "react": "^18.2.0",

--- a/examples/ssg/package.json
+++ b/examples/ssg/package.json
@@ -16,7 +16,7 @@
     "clean": "rimraf .next out"
   },
   "dependencies": {
-    "i18next": "22.3.0",
+    "i18next": "22.4.3",
     "next": "13.0.6",
     "next-i18next": "13.0.0",
     "next-language-detector": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "eslint-plugin-typescript-sort-keys": "^2.1.0",
         "gh-release": "6.0.4",
         "husky": "^8.0.2",
-        "i18next": "^22.0.6",
+        "i18next": "^22.4.3",
         "jest": "^29.3.1",
         "jest-environment-jsdom": "^29.3.1",
         "next": "^13.0.6",
@@ -1852,11 +1852,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
-      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
+      "version": "7.20.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.6.tgz",
+      "integrity": "sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.10"
+        "regenerator-runtime": "^0.13.11"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -9386,9 +9386,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "22.0.6",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-22.0.6.tgz",
-      "integrity": "sha512-RlreNGoPIdDP4QG+qSA9PxZKGwlzmcozbI9ObI6+OyUa/Rp0EjZZA9ubyBjw887zVNZsC+7FI3sXX8oiTzAfig==",
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-22.4.3.tgz",
+      "integrity": "sha512-rnAabD3+i/rMzdg85Eq4VkZjy0Uxe33J1069IQ4R6+cpcM+wL4lWMRClfSweINA0QEfqzSdsfsyLO7SnGAF4fg==",
       "dev": true,
       "funding": [
         {
@@ -9405,7 +9405,7 @@
         }
       ],
       "dependencies": {
-        "@babel/runtime": "^7.17.2"
+        "@babel/runtime": "^7.20.6"
       }
     },
     "node_modules/i18next-fs-backend": {
@@ -18694,11 +18694,11 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
-      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
+      "version": "7.20.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.6.tgz",
+      "integrity": "sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==",
       "requires": {
-        "regenerator-runtime": "^0.13.10"
+        "regenerator-runtime": "^0.13.11"
       }
     },
     "@babel/runtime-corejs3": {
@@ -24475,12 +24475,12 @@
       "dev": true
     },
     "i18next": {
-      "version": "22.0.6",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-22.0.6.tgz",
-      "integrity": "sha512-RlreNGoPIdDP4QG+qSA9PxZKGwlzmcozbI9ObI6+OyUa/Rp0EjZZA9ubyBjw887zVNZsC+7FI3sXX8oiTzAfig==",
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-22.4.3.tgz",
+      "integrity": "sha512-rnAabD3+i/rMzdg85Eq4VkZjy0Uxe33J1069IQ4R6+cpcM+wL4lWMRClfSweINA0QEfqzSdsfsyLO7SnGAF4fg==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.17.2"
+        "@babel/runtime": "^7.20.6"
       }
     },
     "i18next-fs-backend": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "eslint-plugin-typescript-sort-keys": "^2.1.0",
     "gh-release": "6.0.4",
     "husky": "^8.0.2",
-    "i18next": "^22.0.6",
+    "i18next": "^22.4.3",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
     "next": "^13.0.6",


### PR DESCRIPTION
A bug regarding key typings haven introduced in i18next v22.4.0. It's now fixed in latest `^22.4.3` (upstream dep)

- See https://github.com/i18next/i18next/issues/1859#issuecomment-1346177482
- See https://github.com/i18next/i18next/issues/1881

If you are experiencing errors such as `TS2746: This JSX tag's 'children' prop expects a single child of type 'ReactI18NextChild | Iterable ', but multiple children were provided.`...

..simply ensure i18next is at version `^22.4.3` in your package.json and run install.