### PR TITLE
feat(server-side): custom default config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,34 @@ For example, if you want to use `{` and `}` the config would look like this:
 }
 ```
 
+#### Custom `next-i18next.config.js` path
+
+If you want to change the default config path, you can set the environment variable `I18NEXT_DEFAULT_CONFIG_PATH`.
+
+For example, inside the `.env` file you can set a static path:
+```
+I18NEXT_DEFAULT_CONFIG_PATH=/path/to/project/apps/my-app/next-i18next.config.js
+```
+
+Or you can use a trick for dynamic path and set the following inside `next.config.js`:
+
+```js
+process.env.I18NEXT_DEFAULT_CONFIG_PATH = `${__dirname}/next-i18next.config.js`;
+
+// ... Some other imports
+
+const { i18n } = require('./next-i18next.config');
+
+// ... Some other code
+
+module.exports = {
+  i18n,
+  ...
+};
+```
+
+This means that the i18n configuration file will be in the same directory as `next.config.js` and it doesn't matter where your current working directory is. This helps for example for `nx` when you have monorepo and start your application from project root but the application is in `apps/{appName}`.
+
 ## Notes
 
 ### Vercel and Netlify

--- a/src/serverSideTranslations.ts
+++ b/src/serverSideTranslations.ts
@@ -9,7 +9,7 @@ import { globalI18n } from './appWithTranslation'
 import { UserConfig, SSRConfig } from './types'
 import { getFallbackForLng, unique } from './utils'
 
-const DEFAULT_CONFIG_PATH = './next-i18next.config.js'
+const { I18NEXT_DEFAULT_CONFIG_PATH: DEFAULT_CONFIG_PATH = './next-i18next.config.js' } = process.env
 
 export const serverSideTranslations = async (
   initialLocale: string,


### PR DESCRIPTION
To solve issues like this one: https://github.com/nrwl/nx/discussions/4983, and to not create hacky functions I suggest the following change.

It doesn't break anything but it adds the ability to set the default config path.

It will allow you to simply use the package in NX monorepo with the changes from the `dynamic path` example.