### PR TITLE
fix(types): change fixed types to be boolean types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -24,10 +24,10 @@ type NextJsI18NConfig = {
   domains?: {
     defaultLocale: string
     domain: string
-    http?: true
+    http?: boolean
     locales?: string[]
   }[]
-  localeDetection?: false
+  localeDetection?: boolean
   locales: string[]
 }
 


### PR DESCRIPTION
When using `appWithTranslation` with a config passed in, and `localeDetection` set to `false` in an i18n config, type of `boolean` (true/false) in the config doesn't match type of `false` from next-i18next and throws an error on build.

```js
./src/pages/_app.tsx:142:40
Type error: Argument of type '{ i18n: { locales: any; defaultLocale: string; localeDetection: boolean; domains: any; }; use: any[]; backend: { loadPath: string; }; debug: boolean; serializeConfig: boolean; nsSeparator: string; ns: string[]; }' is not assignable to parameter of type 'UserConfig'.
  Type '{ i18n: { locales: any; defaultLocale: string; localeDetection: boolean; domains: any; }; use: any[]; backend: { loadPath: string; }; debug: boolean; serializeConfig: boolean; nsSeparator: string; ns: string[]; }' is not assignable to type '{ i18n: NextJsI18NConfig; localeExtension?: string | undefined; localePath?: string | ((locale: string, namespace: string, missing: boolean) => string) | undefined; ... 4 more ...; use?: any[] | undefined; }'.
    The types of 'i18n.localeDetection' are incompatible between these types.
     Type 'boolean' is not assignable to type 'false'.

  140 | };
  141 |
> 142 | export default appWithTranslation(App, nextI18NextConfig);
      |                                        ^
  143 |
```

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)