### PR TITLE
Update SSRConfig ns type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ import {
   i18n as I18NextClient,
   TFunction as I18NextTFunction,
   TypeOptions,
+  Namespace,
 } from 'i18next'
 import { appWithTranslation, i18n } from './'
 
@@ -73,7 +74,7 @@ export type SSRConfig = {
   _nextI18Next?: {
     initialI18nStore: any
     initialLocale: string
-    ns: string[]
+    ns: Namespace[]
     userConfig: UserConfig | null
   }
 }


### PR DESCRIPTION
Thanks for developing a great library!

The `useTranslation` function completes the namespace defined in `CustomTypeOptions` on `i18next.d.ts`, but the `serverSideTranslations` function does not, so I changed the type.

(If the change causes any inconvenience, close this PR.)

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
