### PR TITLE
Update serverSideTranslation args type

### DIFF
--- a/src/serverSideTranslations.ts
+++ b/src/serverSideTranslations.ts
@@ -8,6 +8,7 @@ import { globalI18n } from './appWithTranslation'
 
 import { UserConfig, SSRConfig } from './types'
 import { getFallbackForLng, unique } from './utils'
+import { Namespace } from 'i18next'
 
 let DEFAULT_CONFIG_PATH = './next-i18next.config.js'
 
@@ -22,8 +23,8 @@ if (process.env.I18NEXT_DEFAULT_CONFIG_PATH) {
 }
 
 export const serverSideTranslations = async (
-  initialLocale: string,
-  namespacesRequired: string[] | undefined = undefined,
+  initialLocale: Namespace[number],
+  namespacesRequired: Namespace[number][] | undefined = undefined,
   configOverride: UserConfig | null = null,
   extraLocales: string[] | false = false
 ): Promise<SSRConfig> => {


### PR DESCRIPTION
Thanks for developing a great library!

The `useTranslation` function completes the namespace defined in `CustomTypeOptions` on `i18next.d.ts`, but the `serverSideTranslations` function does not, so I changed the type.

(If the change causes any inconvenience, close this PR.)

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
