### PR TITLE
fix: allow user provided affixes to be used without providing localeStructure

### DIFF
--- a/src/config/createConfig.test.ts
+++ b/src/config/createConfig.test.ts
@@ -304,6 +304,26 @@ describe('createConfig', () => {
           'public/locales/en/common.json'
         )
       })
+
+      it('uses user provided prefix/suffix without user provided localeStructure', () => {
+        ;(fs.existsSync as jest.Mock).mockReset()
+        ;(fs.existsSync as jest.Mock).mockReturnValueOnce(false)
+
+        const config = createConfig.bind(null, {
+          interpolation: {
+            prefix: '^^',
+            suffix: '$$',
+          },
+          lng: 'en',
+        } as UserConfig)
+
+        expect(config).toThrow(
+          'Default namespace not found at public/locales/en/common.json'
+        )
+        expect(fs.existsSync).toHaveBeenCalledWith(
+          'public/locales/en/common.json'
+        )
+      })
     })
 
     describe('hasCustomBackend', () => {

--- a/src/config/createConfig.ts
+++ b/src/config/createConfig.ts
@@ -33,7 +33,6 @@ export const createConfig = (
     lng,
     localeExtension,
     localePath,
-    localeStructure,
     nonExplicitSupportedLngs,
   } = combinedConfig
 
@@ -53,7 +52,15 @@ export const createConfig = (
       [combinedConfig.fallbackLng] = locales
   }
 
-  const { fallbackLng } = combinedConfig
+  const userPrefix = userConfig?.interpolation?.prefix;
+  const userSuffix = userConfig?.interpolation?.suffix;
+  const prefix = userPrefix ?? '{{';
+  const suffix = userSuffix ?? '}}';
+  if (typeof userConfig?.localeStructure !== 'string' && (userPrefix || userSuffix)) {
+    combinedConfig.localeStructure = `${prefix}lng${suffix}/${prefix}ns${suffix}`;
+  }
+
+  const { fallbackLng, localeStructure } = combinedConfig
 
   if (nonExplicitSupportedLngs) {
     const createFallbackObject = (
@@ -108,8 +115,6 @@ export const createConfig = (
         typeof lng !== 'undefined'
       ) {
         if (typeof localePath === 'string') {
-          const prefix = userConfig?.interpolation?.prefix ?? '{{'
-          const suffix = userConfig?.interpolation?.suffix ?? '}}'
           const defaultLocaleStructure = localeStructure
             .replace(`${prefix}lng${suffix}`, lng)
             .replace(`${prefix}ns${suffix}`, defaultNS)
@@ -228,8 +233,6 @@ export const createConfig = (
           return unique(allNamespaces)
         }
 
-        const prefix = userConfig?.interpolation?.prefix ?? '{{'
-        const suffix = userConfig?.interpolation?.suffix ?? '}}'
         if (localeStructure.indexOf(`${prefix}lng${suffix}`) > localeStructure.indexOf(`${prefix}ns${suffix}`)) {
           throw new Error(
             'Must provide all namespaces in ns option if using a localeStructure that is not namespace-listable like lng/ns'


### PR DESCRIPTION
Fixes #2099 

As always, thanks for your hard work on this open source library. It's been an amazing benefit, many kudos 🙇 

This PR updates the library to allow interpolation affixes to be configured without setting the `localeStructure` field. This will improve developer experience and simplify user defined config.

If a manual `localeStructure`	 is provided, the user will need to ensure it conforms to their custom affixes. 

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
