### PR TITLE
fix serverSideTranslations args

### DIFF
--- a/src/serverSideTranslations.ts
+++ b/src/serverSideTranslations.ts
@@ -22,9 +22,13 @@ if (process.env.I18NEXT_DEFAULT_CONFIG_PATH) {
   DEFAULT_CONFIG_PATH = process.env.I18NEXT_DEFAULT_CONFIG_PATH
 }
 
+type ArrayElementOrSelf<T> = T extends Array<infer U> ? U[] : T[]
+
 export const serverSideTranslations = async (
-  initialLocale: Namespace[number],
-  namespacesRequired: Namespace[number][] | undefined = undefined,
+  initialLocale: string,
+  namespacesRequired:
+    | ArrayElementOrSelf<Namespace>
+    | undefined = undefined,
   configOverride: UserConfig | null = null,
   extraLocales: string[] | false = false
 ): Promise<SSRConfig> => {


### PR DESCRIPTION
#2097 change was incorrect. Sorry about that.

At this time (v13.2.0), we ended up with the same type information as before we merged #2097, so we fixed that.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
