### PR TITLE
docs: improve changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 - requires i18next >= v23.0.1
 - requires react-i18next >= v13.0.0
 
+### Breaking changes
+
+[i18next 13.0.0](https://github.com/i18next/i18next/releases/tag/v23.0.0) dropped support for older browsers.
+From nextjs 13, you can use the [transpilePackages](https://nextjs.org/docs/app/api-reference/next-config-js/transpilePackages)
+to avoid issues.
+
+```js
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  transpilePackages: ['i18next'],
+}
+module.exports = nextConfig
+```
+
 ## 13.3.0
 
 - using a custom backend on server side should also lazy load the passed namespaces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Breaking changes
 
-[i18next 13.0.0](https://github.com/i18next/i18next/releases/tag/v23.0.0) dropped support for older browsers.
+[i18next 23.0.0](https://github.com/i18next/i18next/releases/tag/v23.0.0) dropped support for older browsers.
 From nextjs 13, you can use the [transpilePackages](https://nextjs.org/docs/app/api-reference/next-config-js/transpilePackages)
 to avoid issues.
 


### PR DESCRIPTION
@adrai just a quick addition to help. 


## Near future

I'll do in a different PR:

- [ ] There's changes for I18Namespaces that I'd like to cover (some projects will break, ie: https://github.com/belgattitude/nextjs-monorepo-example/pull/3931)


## Fixed in upstream since i18next 23.0.2
- [x] ~About transpilePackages... I feel this upstream PR https://github.com/i18next/i18next/issues/1948 is very optimistic... I'm currently testing this out, cause it does not pass es2019 thresholds - I'll debug I see with caniuse~