### PR TITLE
fix: correct namespacesRequired type in serverSideTranslations

### DIFF
--- a/src/serverSideTranslations.ts
+++ b/src/serverSideTranslations.ts
@@ -22,7 +22,7 @@ if (process.env.I18NEXT_DEFAULT_CONFIG_PATH) {
   DEFAULT_CONFIG_PATH = process.env.I18NEXT_DEFAULT_CONFIG_PATH
 }
 
-type ArrayElementOrSelf<T> = T extends Array<infer U> ? U[] : T[]
+type ArrayElementOrSelf<T> = T extends ReadonlyArray<infer U> ? U[] : T[]
 
 export const serverSideTranslations = async (
   initialLocale: string,


### PR DESCRIPTION
Fixes #2201 

`Namespace` is not extending `Array` but `ReadonlyArray` so `ArrayElementOrSelf<Namespace>` is evaluated to `(readonly string[])[]` instead of `string[]`.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

