### PR TITLE
refactor: reuse existing instance

### DIFF
--- a/src/appWithTranslation.client.test.tsx
+++ b/src/appWithTranslation.client.test.tsx
@@ -277,18 +277,18 @@ describe('appWithTranslation', () => {
     expect(args[0].i18n.language).toBe('de')
   })
 
-  it('does not re-call createClient on re-renders unless locale or props have changed', () => {
+  it('does not re-call createClient on re-renders', () => {
     const { rerender } = renderComponent()
     expect(createClient).toHaveBeenCalledTimes(1)
     rerender(<DummyApp {...defaultRenderProps} />)
     expect(createClient).toHaveBeenCalledTimes(1)
     const newProps = createProps()
     rerender(<DummyApp {...newProps} />)
-    expect(createClient).toHaveBeenCalledTimes(2)
+    expect(createClient).toHaveBeenCalledTimes(1)
     newProps.pageProps._nextI18Next.initialLocale = 'de'
     newProps.router.locale = 'de'
     rerender(<DummyApp {...newProps} />)
-    expect(createClient).toHaveBeenCalledTimes(3)
+    expect(createClient).toHaveBeenCalledTimes(1)
   })
 
   it('assures locale key is set to the right value', () => {

--- a/src/appWithTranslation.tsx
+++ b/src/appWithTranslation.tsx
@@ -67,6 +67,7 @@ export const appWithTranslation = <Props extends NextJsAppProps>(
 
       let instance = instanceRef.current
       if (instance) {
+        instance.changeLanguage(locale)
         if (resources) {
           for (const locale of Object.keys(resources)) {
             for (const ns of Object.keys(resources[locale])) {

--- a/src/appWithTranslation.tsx
+++ b/src/appWithTranslation.tsx
@@ -9,6 +9,7 @@ import createClient from './createClient'
 import { SSRConfig, UserConfig } from './types'
 
 import { i18n as I18NextClient } from 'i18next'
+import { useIsomorphicLayoutEffect } from './utils'
 export {
   Trans,
   useTranslation,
@@ -31,73 +32,93 @@ export const appWithTranslation = <Props extends NextJsAppProps>(
 
     const instanceRef = useRef<I18NextClient | null>(null)
 
-    // Memoize the instance and only re-initialize when either:
-    // 1. The route changes (non-shallowly)
-    // 2. Router locale changes
-    // 3. UserConfig override changes
-    const i18n: I18NextClient | null = useMemo(() => {
-      if (!_nextI18Next && !configOverride) return null
+    /**
+     * Memoize i18n instance and reuse it rather than creating new instance.
+     * When the locale or resources are changed after instance was created,
+     * we will update the instance in `useLayoutEffect` below.
+     */
+    const [i18n, updateData]: [I18NextClient | null, any?] =
+      useMemo(() => {
+        if (!_nextI18Next && !configOverride) return [null]
 
-      const userConfig = configOverride ?? _nextI18Next?.userConfig
+        const userConfig = configOverride ?? _nextI18Next?.userConfig
 
-      if (!userConfig) {
-        throw new Error(
-          'appWithTranslation was called without a next-i18next config'
-        )
+        if (!userConfig) {
+          throw new Error(
+            'appWithTranslation was called without a next-i18next config'
+          )
+        }
+
+        if (!userConfig?.i18n) {
+          throw new Error(
+            'appWithTranslation was called without config.i18n'
+          )
+        }
+
+        if (!userConfig?.i18n?.defaultLocale) {
+          throw new Error(
+            'config.i18n does not include a defaultLocale property'
+          )
+        }
+
+        const { initialI18nStore } = _nextI18Next || {}
+        const resources = configOverride?.resources
+          ? configOverride.resources
+          : initialI18nStore
+
+        if (!locale) locale = userConfig.i18n.defaultLocale
+
+        let instance = instanceRef.current
+        if (instance) {
+          return [
+            instance,
+            {
+              locale,
+              resources,
+            },
+          ]
+        } else {
+          instance = createClient({
+            ...createConfig({
+              ...userConfig,
+              lng: locale,
+            }),
+            lng: locale,
+            ns,
+            resources,
+          }).i18n
+
+          globalI18n = instance
+          instanceRef.current = instance
+          return [instance]
+        }
+      }, [_nextI18Next, locale, ns])
+
+    /**
+     * Since calling some methods on existing i18n instance can cause state update in react,
+     * we need to call the methods in `useLayoutEffect` to prevent state update in render phase.
+     */
+    useIsomorphicLayoutEffect(() => {
+      if (!i18n || !updateData) {
+        return
       }
+      const { locale, resources } = updateData
 
-      if (!userConfig?.i18n) {
-        throw new Error(
-          'appWithTranslation was called without config.i18n'
-        )
-      }
-
-      if (!userConfig?.i18n?.defaultLocale) {
-        throw new Error(
-          'config.i18n does not include a defaultLocale property'
-        )
-      }
-
-      const { initialI18nStore } = _nextI18Next || {}
-      const resources = configOverride?.resources
-        ? configOverride.resources
-        : initialI18nStore
-
-      if (!locale) locale = userConfig.i18n.defaultLocale
-
-      let instance = instanceRef.current
-      if (instance) {
-        instance.changeLanguage(locale)
-        if (resources) {
-          for (const locale of Object.keys(resources)) {
-            for (const ns of Object.keys(resources[locale])) {
-              instance.addResourceBundle(
-                locale,
-                ns,
-                resources[locale][ns],
-                true,
-                true
-              )
-            }
+      i18n.changeLanguage(locale)
+      if (resources) {
+        for (const locale of Object.keys(resources)) {
+          for (const ns of Object.keys(resources[locale])) {
+            i18n.addResourceBundle(
+              locale,
+              ns,
+              resources[locale][ns],
+              true,
+              true
+            )
           }
         }
-      } else {
-        instance = createClient({
-          ...createConfig({
-            ...userConfig,
-            lng: locale,
-          }),
-          lng: locale,
-          ns,
-          resources,
-        }).i18n
-
-        globalI18n = instance
-        instanceRef.current = instance
       }
-
-      return instance
-    }, [_nextI18Next, locale, ns])
+    }, [i18n, updateData])
 
     return i18n !== null ? (
       <I18nextProvider i18n={i18n}>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import { FallbackLng, FallbackLngObjList } from 'i18next'
+import { useLayoutEffect, useEffect } from 'react'
 
 export const getFallbackForLng = (
   lng: string,
@@ -28,3 +29,13 @@ export const getFallbackForLng = (
 
 export const unique = (list: string[]) =>
   Array.from(new Set<string>(list))
+
+/**
+ * This hook behaves like `useLayoutEffect` on the client,
+ * and `useEffect` on the server(no effect).
+ *
+ * Since using `useLayoutEffect` on the server cause warning messages in nextjs,
+ * this hook is workaround for that.
+ */
+export const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect


### PR DESCRIPTION
This PR changes how next-i18next loads resources on page or locale change.

Instead of creating a new instance on page or locale change, the change uses [`addResourceBundle`](https://www.i18next.com/overview/api#addresourcebundle) method to load newly changed resources if instance was already created.

I made this change because I found an edge-case:
1. Enter page with `getStaticProps` and `serverSideTranslations` configured.
2. Move to page without `serverSideTranslations`, instead load translations in client-side with i18next-http-backend;
Also I used `suspense` option to `true`
3. Component with `useTranslation` hook got suspended, and it suspends forever because i18next instance is created repeatedly, thus not initialized forever.

After applying this patch, the infinite suspending issue was removed.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)