### PR TITLE
feat: Rendering pages on browser when Instance i18n finished initiali…

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export type UserConfig = {
   reloadOnPrerender?: boolean
   serializeConfig?: boolean
   use?: any[]
+  clientAwaitInit?: boolean
 } & InitOptions
 
 export type InternalConfig = Omit<UserConfig, 'i18n'> &


### PR DESCRIPTION
Rendering pages on browser when Instance i18n finished initialization completely.

Rendering pages after loading resources of backend to resolve error `Text content does not match server-rendered HTML` on NEXT.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [ ] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)