### PR TITLE
types: re-add `@types/hoist-non-react-statics` to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.2",
+        "@types/hoist-non-react-statics": "^3.3.6",
         "core-js": "^3",
         "hoist-non-react-statics": "^3.3.2",
         "i18next-fs-backend": "^2.6.0"
@@ -40,7 +41,6 @@
         "@size-limit/webpack": "^10.0.2",
         "@size-limit/webpack-why": "^10.0.2",
         "@testing-library/react": "^14.0.0",
-        "@types/hoist-non-react-statics": "^3.3.6",
         "@types/jest": "^29.5.7",
         "@types/node": "^20.8.10",
         "@types/react": "^18.2.33",
@@ -4221,7 +4221,6 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.6.tgz",
       "integrity": "sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==",
-      "dev": true,
       "dependencies": {
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
@@ -4340,14 +4339,12 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "node_modules/@types/react": {
       "version": "18.2.33",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.33.tgz",
       "integrity": "sha512-v+I7S+hu3PIBoVkKGpSYYpiBT1ijqEzWpzQD62/jm4K74hPpSP7FF9BnKG6+fg2+62weJYkkBWDJlZt5JO/9hg==",
-      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -4366,8 +4363,7 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "node_modules/@types/semver": {
       "version": "7.5.4",
@@ -7603,8 +7599,7 @@
     "node_modules/csstype": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-      "dev": true
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "node_modules/cypress": {
       "version": "13.4.0",
@@ -21818,7 +21813,6 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.6.tgz",
       "integrity": "sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==",
-      "dev": true,
       "requires": {
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
@@ -21930,14 +21924,12 @@
     "@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "@types/react": {
       "version": "18.2.33",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.33.tgz",
       "integrity": "sha512-v+I7S+hu3PIBoVkKGpSYYpiBT1ijqEzWpzQD62/jm4K74hPpSP7FF9BnKG6+fg2+62weJYkkBWDJlZt5JO/9hg==",
-      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -21956,8 +21948,7 @@
     "@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "@types/semver": {
       "version": "7.5.4",
@@ -24356,8 +24347,7 @@
     "csstype": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-      "dev": true
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "cypress": {
       "version": "13.4.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "@size-limit/webpack": "^10.0.2",
     "@size-limit/webpack-why": "^10.0.2",
     "@testing-library/react": "^14.0.0",
-    "@types/hoist-non-react-statics": "^3.3.6",
     "@types/jest": "^29.5.7",
     "@types/node": "^20.8.10",
     "@types/react": "^18.2.33",
@@ -133,6 +132,7 @@
     "webpack": "^5.89.0"
   },
   "dependencies": {
+    "@types/hoist-non-react-statics": "^3.3.6",
     "@babel/runtime": "^7.23.2",
     "core-js": "^3",
     "hoist-non-react-statics": "^3.3.2",


### PR DESCRIPTION
Fixes #2315

Reverts #2310

---

From #2310:

> type declaration files are typically used during development and compilation but are not required at runtime.

This is generally true, however `next-i18next` actually relies on types from `hoist-non-react-statics` which are exposed to the user:

https://github.com/i18next/next-i18next/blob/fe1b79a596f269bca9410d00e340e2dcfb633db0/src/appWithTranslation.tsx#L2

https://github.com/i18next/next-i18next/blob/fe1b79a596f269bca9410d00e340e2dcfb633db0/src/appWithTranslation.tsx#L129

If types are not included when installing the library, users will experience types errors, 
that might be hidden if `skipLibCheck` typescript compiler option is set to `true` (like in #2315).

---

If you don't want that `@types` package is always installed you should use `peerDependencies` alongside [`peerDependenciesMeta`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json/?v=true#peerdependenciesmeta).
However, this will require user to manually install `@types` package,
so a mention to this should be added in all relevant places.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
