### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "next-i18next",
   "version": "16.0.7",
-  "repository": "git@github.com:i18next/next-i18next.git",
+  "repository": "git+https://github.com/i18next/next-i18next.git",
   "author": "i18next",
   "funding": [
     {


### PR DESCRIPTION
## Summary
- replace the SSH-only repository URL with a public HTTPS Git URL
- keep npm repository metadata usable without GitHub SSH credentials

## Verification
- ESLint (`eslint src`)
- TypeScript checks for both Pages Router and App Router configurations
- Jest: 169 tests passed; 18 existing Windows path-separator assertions failed because they expect `/` instead of `\`
- `pnpm pack --dry-run --json`
- direct package metadata assertion
- `git diff --check`